### PR TITLE
Rename YapDatabase.Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 1.1
+# 1.1.1
+
+1. [[YAP-11](https://github.com/danthorpe/YapDatabaseExtensions/pull/11)]: Renames `YapDatabase.Index` to `YapDB.Index`. 
+
+# 1.1.0
 
 1. [[YAP-7](https://github.com/danthorpe/YapDatabaseExtensions/pull/7)]: Support `SequenceType` in arguments where appropriate. This became a bit of a significant refactor.
     - [x] `read` at index(es), by key(s) for value(s), object(s)
@@ -22,7 +26,7 @@
     	- [x] BrightFutures
     	- [x] SwiftTask
 
-# 1.0
+# 1.0.0
 - [x] Persistable & Saveable protocols
 - [x] Metadata protocols
 - [x] YapDatabase.Index

--- a/Pod/Common/Read.swift
+++ b/Pod/Common/Read.swift
@@ -9,28 +9,28 @@ extension YapDatabaseReadTransaction {
 
     /**
         Reads the object sored at this index using the transaction.
-        :param: index The YapDatabase.Index value.
+        :param: index The YapDB.Index value.
         :returns: An optional AnyObject.
     */
-    public func readAtIndex(index: YapDatabase.Index) -> AnyObject? {
+    public func readAtIndex(index: YapDB.Index) -> AnyObject? {
         return objectForKey(index.key, inCollection: index.collection)
     }
 
     /**
         Reads the object sored at this index using the transaction.
-        :param: index The YapDatabase.Index value.
+        :param: index The YapDB.Index value.
         :returns: An optional Object.
     */
-    public func readAtIndex<Object where Object: Persistable>(index: YapDatabase.Index) -> Object? {
+    public func readAtIndex<Object where Object: Persistable>(index: YapDB.Index) -> Object? {
         return readAtIndex(index) as? Object
     }
 
     /**
         Unarchives a value type if stored at this index
-        :param: index The YapDatabase.Index value.
+        :param: index The YapDB.Index value.
         :returns: An optional Value.
     */
-    public func readAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDatabase.Index) -> Value? {
+    public func readAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDB.Index) -> Value? {
         return valueFromArchive(readAtIndex(index))
     }
 }
@@ -39,19 +39,19 @@ extension YapDatabaseReadTransaction {
 
     /**
         Reads the object sored at these indexes using the transaction.
-        :param: indexes An array of YapDatabase.Index values.
+        :param: indexes An array of YapDB.Index values.
         :returns: An array of Object instances.
     */
-    public func readAtIndexes<Object where Object: Persistable>(indexes: [YapDatabase.Index]) -> [Object] {
+    public func readAtIndexes<Object where Object: Persistable>(indexes: [YapDB.Index]) -> [Object] {
         return map(indexes, readAtIndex)
     }
 
     /**
         Reads the value sored at these indexes using the transaction.
-        :param: indexes An array of YapDatabase.Index values.
+        :param: indexes An array of YapDB.Index values.
         :returns: An array of Value instances.
     */
-    public func readAtIndexes<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(indexes: [YapDatabase.Index]) -> [Value] {
+    public func readAtIndexes<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(indexes: [YapDB.Index]) -> [Value] {
         return map(indexes, readAtIndex)
     }
 }
@@ -111,15 +111,15 @@ extension YapDatabaseReadTransaction {
 
 extension YapDatabaseConnection {
 
-    public func readAtIndex(index: YapDatabase.Index) -> AnyObject? {
+    public func readAtIndex(index: YapDB.Index) -> AnyObject? {
         return read({ $0.readAtIndex(index) })
     }
 
-    public func readAtIndex<Object where Object: Persistable>(index: YapDatabase.Index) -> Object? {
+    public func readAtIndex<Object where Object: Persistable>(index: YapDB.Index) -> Object? {
         return read({ $0.readAtIndex(index) })
     }
 
-    public func readAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDatabase.Index) -> Value? {
+    public func readAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDB.Index) -> Value? {
         return read({ $0.readAtIndex(index) })
     }
 
@@ -127,11 +127,11 @@ extension YapDatabaseConnection {
 
 extension YapDatabaseConnection {
 
-    public func readAtIndexes<Object where Object: Persistable>(indexes: [YapDatabase.Index]) -> [Object] {
+    public func readAtIndexes<Object where Object: Persistable>(indexes: [YapDB.Index]) -> [Object] {
         return read({ $0.readAtIndexes(indexes) })
     }
 
-    public func readAtIndexes<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(indexes: [YapDatabase.Index]) -> [Value] {
+    public func readAtIndexes<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(indexes: [YapDB.Index]) -> [Value] {
         return read({ $0.readAtIndexes(indexes) })
     }
 }
@@ -184,22 +184,22 @@ extension YapDatabaseConnection {
 
 extension YapDatabaseConnection {
 
-    public func asyncReadAtIndex<Object where Object: Persistable>(index: YapDatabase.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (Object?) -> Void) {
+    public func asyncReadAtIndex<Object where Object: Persistable>(index: YapDB.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (Object?) -> Void) {
         asyncRead({ $0.readAtIndex(index) }, queue: queue, completion: completion)
     }
 
-    public func asyncReadAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDatabase.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (Value?) -> Void) {
+    public func asyncReadAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDB.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (Value?) -> Void) {
         asyncRead({ $0.readAtIndex(index) }, queue: queue, completion: completion)
     }
 }
 
 extension YapDatabaseConnection {
 
-    public func asyncReadAtIndexes<Object where Object: Persistable>(indexes: [YapDatabase.Index], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([Object]) -> Void) {
+    public func asyncReadAtIndexes<Object where Object: Persistable>(indexes: [YapDB.Index], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([Object]) -> Void) {
         asyncRead({ $0.readAtIndexes(indexes) }, queue: queue, completion: completion)
     }
 
-    public func asyncReadAtIndexes<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(indexes: [YapDatabase.Index], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([Value]) -> Void) {
+    public func asyncReadAtIndexes<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(indexes: [YapDB.Index], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([Value]) -> Void) {
         asyncRead({ $0.readAtIndexes(indexes) }, queue: queue, completion: completion)
     }
 }
@@ -242,22 +242,22 @@ extension YapDatabaseConnection {
 
 extension YapDatabase {
 
-    public func readAtIndex<Object where Object: Persistable>(index: YapDatabase.Index) -> Object? {
+    public func readAtIndex<Object where Object: Persistable>(index: YapDB.Index) -> Object? {
         return newConnection().readAtIndex(index)
     }
 
-    public func readAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDatabase.Index) -> Value? {
+    public func readAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDB.Index) -> Value? {
         return newConnection().readAtIndex(index)
     }
 }
 
 extension YapDatabase {
 
-    public func readAtIndexes<Object where Object: Persistable>(indexes: [YapDatabase.Index]) -> [Object] {
+    public func readAtIndexes<Object where Object: Persistable>(indexes: [YapDB.Index]) -> [Object] {
         return newConnection().readAtIndexes(indexes)
     }
 
-    public func readAtIndexes<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(indexes: [YapDatabase.Index]) -> [Value] {
+    public func readAtIndexes<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(indexes: [YapDB.Index]) -> [Value] {
         return newConnection().readAtIndexes(indexes)
     }
 }
@@ -311,11 +311,11 @@ extension YapDatabase {
 
 extension YapDatabase {
 
-    public func asyncReadAtIndex<Object where Object: Persistable>(index: YapDatabase.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (Object?) -> Void) {
+    public func asyncReadAtIndex<Object where Object: Persistable>(index: YapDB.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (Object?) -> Void) {
         newConnection().asyncReadAtIndex(index, queue: queue, completion: completion)
     }
 
-    public func asyncReadAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDatabase.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (Value?) -> Void) {
+    public func asyncReadAtIndex<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(index: YapDB.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (Value?) -> Void) {
         newConnection().asyncReadAtIndex(index, queue: queue, completion: completion)
     }
 }

--- a/Pod/Common/Remove.swift
+++ b/Pod/Common/Remove.swift
@@ -14,18 +14,18 @@ extension YapDatabaseReadWriteTransaction {
     /**
     Removes the object stored at this index.
 
-    :param: index A YapDatabase.Index
+    :param: index A YapDB.Index
     */
-    public func removeAtIndex(index: YapDatabase.Index) {
+    public func removeAtIndex(index: YapDB.Index) {
         removeObjectForKey(index.key, inCollection: index.collection)
     }
 
     /**
     Removes the object stored at these indexes.
 
-    :param: indexes An Array<YapDatabase.Index>
+    :param: indexes An Array<YapDB.Index>
     */
-    public func removeAtIndexes(indexes: [YapDatabase.Index]) {
+    public func removeAtIndexes(indexes: [YapDB.Index]) {
         indexes.map(removeAtIndex)
     }
 
@@ -55,18 +55,18 @@ extension YapDatabaseConnection {
     /**
     Synchonously removes the object stored at this index.
 
-    :param: index A YapDatabase.Index
+    :param: index A YapDB.Index
     */
-    public func removeAtIndex(index: YapDatabase.Index) {
+    public func removeAtIndex(index: YapDB.Index) {
         write({ $0.removeAtIndex(index) })
     }
 
     /**
     Synchonously removes the object stored at this index.
 
-    :param: indexes An Array<YapDatabase.Index>
+    :param: indexes An Array<YapDB.Index>
     */
-    public func removeAtIndexes(indexes: [YapDatabase.Index]) {
+    public func removeAtIndexes(indexes: [YapDB.Index]) {
         write({ $0.removeAtIndexes(indexes) })
     }
 
@@ -94,22 +94,22 @@ extension YapDatabaseConnection {
     /**
         Asynchonously removes the object stored at this index.
 
-        :param: index A YapDatabase.Index
+        :param: index A YapDB.Index
         :param: queue The dispatch queue to run the completion closure on, defaults to the main queue
         :param: completion A void closure
     */
-    public func asyncRemoveAtIndex(index: YapDatabase.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: () -> Void) {
+    public func asyncRemoveAtIndex(index: YapDB.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: () -> Void) {
         asyncReadWriteWithBlock({ $0.removeAtIndex(index) }, completionQueue: queue, completionBlock: completion)
     }
 
     /**
         Asynchonously removes the object stored at this index.
 
-        :param: indexes An Array<YapDatabase.Index>
+        :param: indexes An Array<YapDB.Index>
         :param: queue The dispatch queue to run the completion closure on, defaults to the main queue
         :param: completion A void closure
     */
-    public func asyncRemoveAtIndexes(indexes: [YapDatabase.Index], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: () -> Void) {
+    public func asyncRemoveAtIndexes(indexes: [YapDB.Index], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: () -> Void) {
         asyncReadWriteWithBlock({ $0.removeAtIndexes(indexes) }, completionQueue: queue, completionBlock: completion)
     }
 
@@ -143,18 +143,18 @@ extension YapDatabase {
     /**
     Synchonously removes the object stored at this index.
 
-    :param: index A YapDatabase.Index
+    :param: index A YapDB.Index
     */
-    public func removeAtIndex(index: YapDatabase.Index) {
+    public func removeAtIndex(index: YapDB.Index) {
         newConnection().removeAtIndex(index)
     }
 
     /**
     Synchonously removes the object stored at this index.
 
-    :param: indexes An Array<YapDatabase.Index>
+    :param: indexes An Array<YapDB.Index>
     */
-    public func removeAtIndexes(indexes: [YapDatabase.Index]) {
+    public func removeAtIndexes(indexes: [YapDB.Index]) {
         newConnection().removeAtIndexes(indexes)
     }
 
@@ -182,22 +182,22 @@ extension YapDatabase {
     /**
     Asynchonously removes the object stored at this index.
 
-    :param: index A YapDatabase.Index
+    :param: index A YapDB.Index
     :param: queue The dispatch queue to run the completion closure on, defaults to the main queue
     :param: completion A void closure
     */
-    public func asyncRemoveAtIndex(index: YapDatabase.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: () -> Void) {
+    public func asyncRemoveAtIndex(index: YapDB.Index, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: () -> Void) {
         newConnection().asyncRemoveAtIndex(index, queue: queue, completion: completion)
     }
 
     /**
     Asynchonously removes the object stored at this index.
 
-    :param: indexes An Array<YapDatabase.Index>
+    :param: indexes An Array<YapDB.Index>
     :param: queue The dispatch queue to run the completion closure on, defaults to the main queue
     :param: completion A void closure
     */
-    public func asyncRemoveAtIndexes(indexes: [YapDatabase.Index], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: () -> Void) {
+    public func asyncRemoveAtIndexes(indexes: [YapDB.Index], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: () -> Void) {
         newConnection().asyncRemoveAtIndexes(indexes, queue: queue, completion: completion)
     }
 

--- a/Pod/Common/Write.swift
+++ b/Pod/Common/Write.swift
@@ -9,7 +9,7 @@ import YapDatabase
 
 extension YapDatabaseReadWriteTransaction {
 
-    func writeAtIndex(index: YapDatabase.Index, object: AnyObject, metadata: AnyObject? = .None) {
+    func writeAtIndex(index: YapDB.Index, object: AnyObject, metadata: AnyObject? = .None) {
         if let metadata: AnyObject = metadata {
             setObject(object, forKey: index.key, inCollection: index.collection, withMetadata: metadata)
         }

--- a/Pod/Common/YapDatabaseExtensions.swift
+++ b/Pod/Common/YapDatabaseExtensions.swift
@@ -43,8 +43,23 @@ public func archivesFromValues<Values, Value where Values: SequenceType, Values.
 
 // MARK: - Persistable
 
-extension YapDatabase {
+/**
 
+This is an empty struct used as a namespace for new types to
+avoid any possible future clashes with `YapDatabase` types.
+
+*/
+public struct YapDB { }
+
+extension YapDB {
+
+    /**
+
+    A database index value type.
+    
+    :param: collection A String
+    :param: key A String
+    */
     public struct Index {
         public let collection: String
         public let key: String
@@ -75,8 +90,8 @@ public protocol ValueMetadataPersistable: Persistable {
     var metadata: MetadataType { get }
 }
 
-public func indexForPersistable<P: Persistable>(persistable: P) -> YapDatabase.Index {
-    return YapDatabase.Index(collection: persistable.dynamicType.collection, key: "\(persistable.identifier)")
+public func indexForPersistable<P: Persistable>(persistable: P) -> YapDB.Index {
+    return YapDB.Index(collection: persistable.dynamicType.collection, key: "\(persistable.identifier)")
 }
 
 internal func map<S: SequenceType, T>(source: S, transform: (S.Generator.Element) -> T?) -> [T] {

--- a/YapDBExtensionsMobile/YapDBExtensionsMobileTests/ReadWriteTests.swift
+++ b/YapDBExtensionsMobile/YapDBExtensionsMobileTests/ReadWriteTests.swift
@@ -242,7 +242,6 @@ class SynchronousRemoveTests: BaseTestCase {
         XCTAssertEqual((db.readAll() as [Barcode]).count, 0, "There should be no barcodes in the database.")
     }
 
-/* - For some reason this doesn't link...
     func testSynchronous_RemoveAtIndexes() {
         let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
 
@@ -250,11 +249,9 @@ class SynchronousRemoveTests: BaseTestCase {
         db.write(_barcodes)
         XCTAssertEqual((db.readAll() as [Barcode]).count, _barcodes.count, "There should be one barcodes in the database.")
 
-        let indexes: [YapDatabase.Index] = map(_barcodes, indexForPersistable)
-        db.removeAtIndexes(indexes)
+        db.removeAtIndexes(map(_barcodes, indexForPersistable))
         XCTAssertEqual((db.readAll() as [Barcode]).count, 0, "There should be no barcodes in the database.")
     }
-*/
 
     func test_RemovePersistable() {
         let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)


### PR DESCRIPTION
Seems to be causing linking issues on Release OS X builds. Will introduce an empty struct to namespace stuff.
