### PR TITLE
Add helper functions for creating YapDatabases

### DIFF
--- a/Pod/Common/YapDatabaseExtensions.swift
+++ b/Pod/Common/YapDatabaseExtensions.swift
@@ -21,7 +21,7 @@ public struct YapDB {
     
     :returns: a String
     */
-    public func pathToDatabase(directory: NSSearchPathDirectory, name: String, suffix: String? = .None) -> String {
+    public static func pathToDatabase(directory: NSSearchPathDirectory, name: String, suffix: String? = .None) -> String {
         let paths = NSSearchPathForDirectoriesInDomains(directory, .UserDomainMask, true)
         let directory: String = (paths.first as? String) ?? NSTemporaryDirectory()
         let filename: String = {
@@ -73,8 +73,7 @@ public struct YapDB {
     :returns: the YapDatabase instance.
     */
     public static func databaseNamed(name: String, operations: DatabaseOperationsBlock? = .None) -> YapDatabase {
-        let path = pathToDatabase(.DocumentDirectory, name, suffix: .None)
-        let db =  YapDatabase(path: path)
+        let db =  YapDatabase(path: pathToDatabase(.DocumentDirectory, name: name, suffix: .None))
         operations?(db)
         return db
     }
@@ -107,7 +106,7 @@ public struct YapDB {
     :returns: the YapDatabase instance.
     */
     public static func testDatabaseForFile(file: String, test: String, operations: DatabaseOperationsBlock? = .None) -> YapDatabase {
-        let path = pathToDatabase(.CachesDirectory, file.lastPathComponent, suffix: test.stringByTrimmingCharactersInSet(NSCharacterSet(charactersInString: "()")))
+        let path = pathToDatabase(.CachesDirectory, name: file.lastPathComponent, suffix: test.stringByTrimmingCharactersInSet(NSCharacterSet(charactersInString: "()")))
         assert(!path.isEmpty, "Path should not be empty.")
         NSFileManager.defaultManager().removeItemAtPath(path, error: nil)
         let db =  YapDatabase(path: path)

--- a/Pod/Common/YapDatabaseExtensions.swift
+++ b/Pod/Common/YapDatabaseExtensions.swift
@@ -40,10 +40,10 @@ public struct YapDB {
     /**
     Conveniently create or read a YapDatabase with the given name in the application's documents directory.
     
-    Optionally, pass a block which receives the database instanced, which is called
+    Optionally, pass a block which receives the database instance, which is called
     before being returned. This block allows for things like registering extensions.
     
-    Typicaly usage in a production environment would be to use this inside a singleton pattern, eg
+    Typical usage in a production environment would be to use this inside a singleton pattern, eg
     
         extension YapDB {
             public static var userDefaults: YapDatabase {
@@ -63,7 +63,7 @@ public struct YapDB {
     
         let userDefaultDatabase = YapDB.userDefaults
     
-    Note that if you can only use this convenience if you only require the default serializers 
+    Note that you can only use this convenience if you use the default serializers
     and sanitizers etc.
 
     :param: name a String, which will be the name of the SQLite database in the documents folder.

--- a/Pod/Common/YapDatabaseExtensions.swift
+++ b/Pod/Common/YapDatabaseExtensions.swift
@@ -6,11 +6,115 @@ import YapDatabase
 
 /**
 
-This is an empty struct used as a namespace for new types to
+This is a struct used as a namespace for new types to
 avoid any possible future clashes with `YapDatabase` types.
 
 */
-public struct YapDB { }
+public struct YapDB {
+
+    /**
+    Helper function for evaluating the path to a database for easy use in the YapDatabase constructor.
+    
+    :param: directory a NSSearchPathDirectory value, use .DocumentDirectory for production.
+    :param: name a String, the name of the sqlite file.
+    :param: suffix a String, will be appended to the name of the file.
+    
+    :returns: a String
+    */
+    public func pathToDatabase(directory: NSSearchPathDirectory, name: String, suffix: String? = .None) -> String {
+        let paths = NSSearchPathForDirectoriesInDomains(directory, .UserDomainMask, true)
+        let directory: String = (paths.first as? String) ?? NSTemporaryDirectory()
+        let filename: String = {
+            if let suffix = suffix {
+                return "\(name)-\(suffix).sqlite"
+            }
+            return "\(name).sqlite"
+            }()
+
+        return directory.stringByAppendingPathComponent(filename)
+    }
+
+    /// Type of closure which can perform operations on newly created/opened database instances.
+    public typealias DatabaseOperationsBlock = (YapDatabase) -> Void
+
+    /**
+    Conveniently create or read a YapDatabase with the given name in the application's documents directory.
+    
+    Optionally, pass a block which receives the database instanced, which is called
+    before being returned. This block allows for things like registering extensions.
+    
+    Typicaly usage in a production environment would be to use this inside a singleton pattern, eg
+    
+        extension YapDB {
+            public static var userDefaults: YapDatabase {
+                get {
+                    struct DatabaseSingleton {
+                        static func database() -> YapDatabase {
+                            return YapDB.databaseNamed("User Defaults")
+                        }
+                        static let instance = DatabaseSingleton.database()
+                    }
+                    return DatabaseSingleton.instance
+                }
+            }
+        }
+
+    which would allow the following behavior in your app:
+    
+        let userDefaultDatabase = YapDB.userDefaults
+    
+    Note that if you can only use this convenience if you only require the default serializers 
+    and sanitizers etc.
+
+    :param: name a String, which will be the name of the SQLite database in the documents folder.
+    :param: operations a DatabaseOperationsBlock closure, which receives the database,
+    but is executed before the database is returned.
+    
+    :returns: the YapDatabase instance.
+    */
+    public static func databaseNamed(name: String, operations: DatabaseOperationsBlock? = .None) -> YapDatabase {
+        let path = pathToDatabase(.DocumentDirectory, name, suffix: .None)
+        let db =  YapDatabase(path: path)
+        operations?(db)
+        return db
+    }
+
+
+    /**
+    Conveniently create an empty database for testing purposes in the app's Caches directory.
+    
+    This function should only be used in unit tests, as it will delete any previously existing 
+    SQLite file with the same path.
+    
+    It should only be used like this inside your test case.
+    
+        func test_MyUnitTest() {
+            let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
+            // etc etc
+        }
+    
+        func test_GivenInitialData_MyUnitTest(initialDataImport: YapDB.DatabaseOperationsBlock) {
+            let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__, operations: initialDataImport)
+            // etc etc
+        }
+    
+    :param: file a String, which should be the swift special macro __FILE__
+    :param: test a String, which should be the swift special macro __FUNCTION__
+    :param: operations a DatabaseOperationsBlock closure, which receives the database,
+    but is executed before the database is returned. This is very useful if you want to 
+    populate the database with some objects before running the test.
+    
+    :returns: the YapDatabase instance.
+    */
+    public static func testDatabaseForFile(file: String, test: String, operations: DatabaseOperationsBlock? = .None) -> YapDatabase {
+        let path = pathToDatabase(.CachesDirectory, file.lastPathComponent, suffix: test.stringByTrimmingCharactersInSet(NSCharacterSet(charactersInString: "()")))
+        assert(!path.isEmpty, "Path should not be empty.")
+        NSFileManager.defaultManager().removeItemAtPath(path, error: nil)
+        let db =  YapDatabase(path: path)
+        operations?(db)
+        return db
+    }
+}
 
 extension YapDB {
 

--- a/YapDBExtensionsMobile/YapDBExtensionsMobileTests/BrightFuturesTests.swift
+++ b/YapDBExtensionsMobile/YapDBExtensionsMobileTests/BrightFuturesTests.swift
@@ -17,7 +17,7 @@ import YapDBExtensionsMobile
 extension AsynchronousWriteTests {
 
     func test_ReadingAndWriting_Object_BrightFuture() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         (db.asyncWrite(person) as Future<Person>).onSuccess { saved in
@@ -29,7 +29,7 @@ extension AsynchronousWriteTests {
     }
 
     func test_ReadingAndWriting_Value_BrightFuture() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of value.")
 
         (db.asyncWrite(barcode) as Future<Barcode>).onSuccess { saved in
@@ -41,7 +41,7 @@ extension AsynchronousWriteTests {
     }
 
     func test_ReadingAndWriting_ValueWithValueMetadata_BrightFuture() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of value with value metadata.")
 
         (db.asyncWrite(product) as Future<Product>).onSuccess { saved in
@@ -56,7 +56,7 @@ extension AsynchronousWriteTests {
 extension AsynchronousReadTests {
 
     func test_Reading_Value_BrightFutures() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         db.write(barcode)
@@ -70,7 +70,7 @@ extension AsynchronousReadTests {
     }
 
     func test_Reading_Object_BrightFutures() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         db.write(person)
@@ -84,7 +84,7 @@ extension AsynchronousReadTests {
     }
 
     func test_Reading_Values_BrightFutures() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         let values = barcodes()
@@ -99,7 +99,7 @@ extension AsynchronousReadTests {
     }
 
     func test_Reading_Objects_BrightFutures() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of object by key.")
 
         let objects = people()
@@ -117,7 +117,7 @@ extension AsynchronousReadTests {
 extension AsynchronousRemoveTests {
 
     func test_RemovePersistable_BrightFuture() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         db.write(barcode)
@@ -132,7 +132,7 @@ extension AsynchronousRemoveTests {
     }
 
     func test_RemovePersistables_BrightFuture() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         let _people = people()

--- a/YapDBExtensionsMobile/YapDBExtensionsMobileTests/Helpers.swift
+++ b/YapDBExtensionsMobile/YapDBExtensionsMobileTests/Helpers.swift
@@ -10,26 +10,6 @@ import XCTest
 import YapDatabase
 import YapDatabaseExtensions
 
-func createYapDatabase(file: String, suffix: String? = .None) -> YapDatabase {
-
-    func pathToDatabase(name: String, suffix: String? = .None) -> String {
-        let paths = NSSearchPathForDirectoriesInDomains(.CachesDirectory, NSSearchPathDomainMask.UserDomainMask, true)
-        let directory: String = (paths.first as? String) ?? NSTemporaryDirectory()
-        let filename: String = {
-            if let suffix = suffix {
-                return "\(name)-\(suffix).sqlite"
-            }
-            return "\(name).sqlite"
-            }()
-        return directory.stringByAppendingPathComponent(filename)
-    }
-
-    let path = pathToDatabase(file.lastPathComponent, suffix: suffix?.stringByTrimmingCharactersInSet(NSCharacterSet(charactersInString: "()")))
-    NSFileManager.defaultManager().removeItemAtPath(path, error: nil)
-
-    return YapDatabase(path: path)
-}
-
 /// Value type with no metadata
 func validateWrite<Value where Value: Saveable, Value: Persistable, Value: Equatable, Value.ArchiverType.ValueType == Value>(saved: Value, original: Value, usingDatabase db: YapDatabase) {
     XCTAssertEqual(saved, original, "The value returned from a save value function should equal the argument.")

--- a/YapDBExtensionsMobile/YapDBExtensionsMobileTests/PromiseKitTests.swift
+++ b/YapDBExtensionsMobile/YapDBExtensionsMobileTests/PromiseKitTests.swift
@@ -16,7 +16,7 @@ import YapDBExtensionsMobile
 extension AsynchronousWriteTests {
 
     func test_ReadingAndWriting_Object_PromiseKit() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         (db.asyncWrite(person) as PromiseKit.Promise<Person>).then { saved -> Void in
@@ -28,7 +28,7 @@ extension AsynchronousWriteTests {
     }
 
     func test_ReadingAndWriting_Value_PromiseKit() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of value.")
 
         (db.asyncWrite(barcode) as PromiseKit.Promise<Barcode>).then { saved -> Void in
@@ -40,7 +40,7 @@ extension AsynchronousWriteTests {
     }
 
     func test_ReadingAndWriting_ValueWithValueMetadata_PromiseKit() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of value with value metadata.")
 
         (db.asyncWrite(product) as PromiseKit.Promise<Product>).then { saved -> Void in
@@ -55,7 +55,7 @@ extension AsynchronousWriteTests {
 extension AsynchronousReadTests {
 
     func test_Reading_Value_PromiseKit() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         db.write(barcode)
@@ -69,7 +69,7 @@ extension AsynchronousReadTests {
     }
 
     func test_Reading_Object_PromiseKit() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         db.write(person)
@@ -83,7 +83,7 @@ extension AsynchronousReadTests {
     }
 
     func test_Reading_Values_PromiseKit() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         let values = barcodes()
@@ -98,7 +98,7 @@ extension AsynchronousReadTests {
     }
 
     func test_Reading_Objects_PromiseKit() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of object by key.")
 
         let objects = people()
@@ -116,7 +116,7 @@ extension AsynchronousReadTests {
 extension AsynchronousRemoveTests {
 
     func test_RemovePersistable_PromiseKit() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         db.write(barcode)
@@ -131,7 +131,7 @@ extension AsynchronousRemoveTests {
     }
 
     func test_RemovePersistables_PromiseKit() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         let _people = people()

--- a/YapDBExtensionsMobile/YapDBExtensionsMobileTests/ReadWriteTests.swift
+++ b/YapDBExtensionsMobile/YapDBExtensionsMobileTests/ReadWriteTests.swift
@@ -37,52 +37,52 @@ class BaseTestCase: XCTestCase {
 class SynchronousReadWriteTests: BaseTestCase {
 
     func test_ReadingNonexisting_Object_ByIndex() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let read: Person? = db.readAtIndex(indexForPersistable(person))
         XCTAssertNil(read, "In an empty database, this should return nil.")
     }
 
     func test_ReadingNonexisting_Value_ByIndex() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let read: Barcode? = db.readAtIndex(indexForPersistable(barcode))
         XCTAssertTrue(read == nil, "In an empty database, this should return nil.")
     }
 
     func test_ReadingNonexisting_Object_ByKey() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let read: Person? = db.read(keyForPersistable(person))
         XCTAssertNil(read, "In an empty database, this should return nil.")
     }
 
     func test_ReadingNonexisting_Value_ByKey() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let read: Barcode? = db.read(keyForPersistable(barcode))
         XCTAssertTrue(read == nil, "In an empty database, this should return nil.")
     }
 
     func test_ReadingNonexisting_Metadata_ByIndex() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let metadata: Product.Metadata? = db.readMetadataAtIndex(indexForPersistable(product))
         XCTAssertTrue(metadata == nil, "In an empty database, this should return nil.")
     }
 
     func test_ReadingAndWriting_Object() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         validateWrite(db.write(person), person, usingDatabase: db)
     }
 
     func test_ReadingAndWriting_Value() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         validateWrite(db.write(barcode), barcode, usingDatabase: db)
     }
 
     func test_ReadingAndWriting_ValueWithValueMetadata() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         validateWrite(db.write(product), product, usingDatabase: db)
     }
 
     func test_ReadingAndWriting_ManyObjects() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
 
         let objects = people()
         db.write(objects)
@@ -92,7 +92,7 @@ class SynchronousReadWriteTests: BaseTestCase {
     }
 
     func test_ReadingAndWriting_ManyValues() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
 
         let values = barcodes()
         db.write(values)
@@ -102,7 +102,7 @@ class SynchronousReadWriteTests: BaseTestCase {
     }
 
     func test_ReadingAnyWriting_ManyObjects_SomeNonexistent() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
 
         let objects = people()
         db.write(objects)
@@ -117,7 +117,7 @@ class SynchronousReadWriteTests: BaseTestCase {
     }
 
     func test_ReadingAnyWriting_ManyValues_SomeNonexistent() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
 
         let values = barcodes()
         db.write(values)
@@ -135,7 +135,7 @@ class SynchronousReadWriteTests: BaseTestCase {
 class AsynchronousWriteTests: BaseTestCase {
 
     func test_Writing_Object() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         db.asyncWrite(person) {
@@ -147,7 +147,7 @@ class AsynchronousWriteTests: BaseTestCase {
     }
 
     func test_Writing_Value() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of value.")
 
         db.asyncWrite(barcode) {
@@ -159,7 +159,7 @@ class AsynchronousWriteTests: BaseTestCase {
     }
 
     func test_Writing_ValueWithValueMetadata() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of value with value metadata.")
 
         db.asyncWrite(product) {
@@ -174,7 +174,7 @@ class AsynchronousWriteTests: BaseTestCase {
 class AsynchronousReadTests: BaseTestCase {
 
     func test_Reading_Index_Value() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value at index.")
 
         db.write(barcode)
@@ -188,7 +188,7 @@ class AsynchronousReadTests: BaseTestCase {
     }
 
     func test_Reading_Index_Object() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of object at index")
 
         db.write(person)
@@ -202,7 +202,7 @@ class AsynchronousReadTests: BaseTestCase {
     }
 
     func test_Reading_Value() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         db.write(barcode)
@@ -216,7 +216,7 @@ class AsynchronousReadTests: BaseTestCase {
     }
 
     func test_Reading_Object() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of object by key.")
 
         db.write(person)
@@ -230,7 +230,7 @@ class AsynchronousReadTests: BaseTestCase {
     }
 
     func test_Reading_Values() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         let values = barcodes()
@@ -245,7 +245,7 @@ class AsynchronousReadTests: BaseTestCase {
     }
 
     func test_Reading_Objects() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of object by key.")
 
         let objects = people()
@@ -260,7 +260,7 @@ class AsynchronousReadTests: BaseTestCase {
     }
 
     func test_ReadingAll_Values() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of all values.")
 
         let values = barcodes()
@@ -275,7 +275,7 @@ class AsynchronousReadTests: BaseTestCase {
     }
 
     func test_ReadingAll_Objects() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of all values.")
 
         let objects = people()
@@ -293,7 +293,7 @@ class AsynchronousReadTests: BaseTestCase {
 class SynchronousRemoveTests: BaseTestCase {
 
     func test_RemoveAtIndex() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
 
         db.write(barcode)
         XCTAssertEqual((db.readAll() as [Barcode]).count, 1, "There should be one barcodes in the database.")
@@ -303,7 +303,7 @@ class SynchronousRemoveTests: BaseTestCase {
     }
 
     func testSynchronous_RemoveAtIndexes() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
 
         let _barcodes = barcodes()
         db.write(_barcodes)
@@ -314,7 +314,7 @@ class SynchronousRemoveTests: BaseTestCase {
     }
 
     func test_RemovePersistable() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
 
         db.write(barcode)
         XCTAssertEqual((db.readAll() as [Barcode]).count, 1, "There should be one barcodes in the database.")
@@ -324,7 +324,7 @@ class SynchronousRemoveTests: BaseTestCase {
     }
 
     func test_RemovePersistables() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
 
         let _barcodes = barcodes()
         db.write(_barcodes)
@@ -338,7 +338,7 @@ class SynchronousRemoveTests: BaseTestCase {
 class AsynchronousRemoveTests: BaseTestCase {
 
     func test_RemoveAtIndex() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         db.write(barcode)
@@ -353,7 +353,7 @@ class AsynchronousRemoveTests: BaseTestCase {
     }
 
     func test_RemovePersistable() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         db.write(barcode)
@@ -368,7 +368,7 @@ class AsynchronousRemoveTests: BaseTestCase {
     }
 
     func test_RemovePersistables() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         let _people = people()

--- a/YapDBExtensionsMobile/YapDBExtensionsMobileTests/SwiftTaskTests.swift
+++ b/YapDBExtensionsMobile/YapDBExtensionsMobileTests/SwiftTaskTests.swift
@@ -17,7 +17,7 @@ import YapDBExtensionsMobile
 extension AsynchronousWriteTests {
 
     func test_ReadingAndWriting_Object_SwiftTask() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         (db.asyncWrite(person) as Task<Void, Person, Void>).success { saved -> Void in
@@ -29,7 +29,7 @@ extension AsynchronousWriteTests {
     }
 
     func test_ReadingAndWriting_Value_SwiftTask() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of value.")
 
         (db.asyncWrite(barcode) as Task<Void, Barcode, Void>).success { saved -> Void in
@@ -41,7 +41,7 @@ extension AsynchronousWriteTests {
     }
 
     func test_ReadingAndWriting_ValueWithValueMetadata_SwiftTask() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of value with value metadata.")
 
         (db.asyncWrite(product) as Task<Void, Product, Void>).success { saved -> Void in
@@ -56,7 +56,7 @@ extension AsynchronousWriteTests {
 extension AsynchronousReadTests {
 
     func test_Reading_Value_SwiftTask() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         db.write(barcode)
@@ -70,7 +70,7 @@ extension AsynchronousReadTests {
     }
 
     func test_Reading_Object_SwiftTask() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         db.write(person)
@@ -84,7 +84,7 @@ extension AsynchronousReadTests {
     }
 
     func test_Reading_Values_SwiftTask() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of value by key.")
 
         let values = barcodes()
@@ -99,7 +99,7 @@ extension AsynchronousReadTests {
     }
 
     func test_Reading_Objects_SwiftTask() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async reading of object by key.")
 
         let objects = people()
@@ -118,7 +118,7 @@ extension AsynchronousReadTests {
 extension AsynchronousRemoveTests {
 
     func test_RemovePersistable_SwiftTask() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         db.write(barcode)
@@ -133,7 +133,7 @@ extension AsynchronousRemoveTests {
     }
 
     func test_RemovePersistables_SwiftTask() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let expectation = expectationWithDescription("Finished async writing of object.")
 
         let _people = people()

--- a/YapDBExtensionsMobile/YapDBExtensionsMobileTests/YapDBExtensionsMobileTests.swift
+++ b/YapDBExtensionsMobile/YapDBExtensionsMobileTests/YapDBExtensionsMobileTests.swift
@@ -15,20 +15,20 @@ import YapDBExtensionsMobile
 class YapDBTests: XCTestCase {
 
     func test_ViewRegistration_NotRegisteredInEmptyDatabase() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let fetch: YapDB.Fetch = products()
         XCTAssertFalse(fetch.isRegisteredInDatabase(db), "Extension should not be registered in fresh database.")
     }
 
     func test_ViewRegistration_RegistersCorrectly() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let fetch: YapDB.Fetch = products()
         fetch.registerInDatabase(db)
         XCTAssertTrue(fetch.isRegisteredInDatabase(db), "Extension should be registered in database.")
     }
 
     func test_AfterRegistration_ViewIsAccessible() {
-        let db = createYapDatabase(__FILE__, suffix: __FUNCTION__)
+        let db = YapDB.testDatabaseForFile(__FILE__, test: __FUNCTION__)
         let fetch: YapDB.Fetch = products()
         fetch.registerInDatabase(db)
         db.newConnection().read { transaction in


### PR DESCRIPTION
e.g. functions for creating a database in production, and for testing.
