### PR TITLE
Implements Saveable on YapDB.Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.0
+
+1. [[YAP-19](https://github.com/danthorpe/YapDatabaseExtensions/pull/19)]: Implements Saveable on YapDB.Index. This makes it easier to store references between YapDatabase objects. In general this is preferable to storing references as `let fooId: Foo.IdentifierType`.
+
 # 1.4.0
 
 1. [[YAP-16](https://github.com/danthorpe/YapDatabaseExtensions/pull/16)]: Adds helper APIs for creating a YapDatabase. Includes a function for creating temporary database for use inside unit tests.

--- a/Pod/Common/YapDatabaseExtensions.swift
+++ b/Pod/Common/YapDatabaseExtensions.swift
@@ -409,3 +409,37 @@ public func == (a: YapDB.Index, b: YapDB.Index) -> Bool {
     return (a.collection == b.collection) && (a.key == b.key)
 }
 
+
+
+// MARK: Saveable
+
+extension YapDB.Index: Saveable {
+    public typealias Archiver = YapDBIndexArchiver
+
+    public var archive: Archiver {
+        return Archiver(self)
+    }
+}
+
+// MARK: Archivers
+
+public final class YapDBIndexArchiver: NSObject, NSCoding, Archiver {
+    public let value: YapDB.Index
+
+    public init(_ v: YapDB.Index) {
+        value = v
+    }
+
+
+    public required init(coder aDecoder: NSCoder) {
+        let collection = aDecoder.decodeObjectForKey("collection") as! String
+        let key = aDecoder.decodeObjectForKey("key") as! String
+        value = YapDB.Index(collection: collection, key: key)
+    }
+
+    public func encodeWithCoder(aCoder: NSCoder) {
+        aCoder.encodeObject(value.collection, forKey: "collection")
+        aCoder.encodeObject(value.key, forKey: "key")
+    }
+}
+

--- a/YapDBExtensionsMobile/Podfile.lock
+++ b/YapDBExtensionsMobile/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - CocoaLumberjack/Extensions (1.9.2):
     - CocoaLumberjack/Core
   - PromiseKit/Swift/Promise (1.5.3)
-  - SwiftTask (3.1.0)
+  - SwiftTask (3.3.0)
   - YapDatabase (2.6.4):
     - YapDatabase/standard (= 2.6.4)
   - YapDatabase/standard (2.6.4):
@@ -42,7 +42,7 @@ SPEC CHECKSUMS:
   BrightFutures: 76c1b0f2ff9694959c8359dad80f42c6e60c4a59
   CocoaLumberjack: 628fca2e88ef06f7cf6817309aa405f325d9a6fa
   PromiseKit: 7ecae7c190ab92ae00aae6ba7f88942107532b8f
-  SwiftTask: e742b3d1fbacc27134600ab383d6a5fe53bb7ea5
+  SwiftTask: 8bc1ec4e0348ce8a40436af737992174485f8996
   YapDatabase: f9051e178a38f48d0f3a78562423a5bc969f1ca3
   YapDatabaseExtensions: 8b91008a89d78236aef83c9dbd1178f849881988
 

--- a/YapDBExtensionsMobile/YapDBExtensionsMobileTests/YapDBExtensionsMobileTests.swift
+++ b/YapDBExtensionsMobile/YapDBExtensionsMobileTests/YapDBExtensionsMobileTests.swift
@@ -35,5 +35,12 @@ class YapDBTests: XCTestCase {
             XCTAssertNotNil(transaction.ext(fetch.name) as? YapDatabaseViewTransaction, "The view should be accessible inside a read transaction.")
         }
     }
+
+    func test_YapDBIndex_EncodingAndDecoding() {
+        let index = YapDB.Index(collection: "Foo", key: "Bar")
+        let _index: YapDB.Index? = valueFromArchive(archiveFromValue(index))
+        XCTAssertTrue(_index != nil, "Unarchived archive should not be nil")
+        XCTAssertEqual(index, _index!, "Unarchived archive should equal the original.")
+    }
 }
 


### PR DESCRIPTION
This will allow for simple storing of database indexes inside other types, which would aid in storing references.
