### PR TITLE
Support Secondary Indexes in YapDB.Fetch

### DIFF
--- a/framework/YapDatabaseExtensions/Common/YapDB.swift
+++ b/framework/YapDatabaseExtensions/Common/YapDB.swift
@@ -425,8 +425,6 @@ extension YapDB {
             }
         }
     }
-
-
 }
 
 extension YapDB {

--- a/framework/YapDatabaseExtensions/Common/YapDB.swift
+++ b/framework/YapDatabaseExtensions/Common/YapDB.swift
@@ -8,7 +8,7 @@ protocol YapDatabaseViewProducer {
     func createDatabaseView() -> YapDatabaseView
 }
 
-protocol YapDatabaseViewRegistrar {
+protocol YapDatabaseExtensionRegistrar {
     func isRegisteredInDatabase(database: YapDatabase) -> Bool
     func registerInDatabase(database: YapDatabase, withConnection: YapDatabaseConnection?)
 }
@@ -20,25 +20,28 @@ extension YapDB {
     Request type, as it defines what will be fetched out of the database. The Fetch
     instance should be used by injecting it into a FetchConfiguration.
     */
-    public enum Fetch: YapDatabaseViewRegistrar {
+    public enum Fetch: YapDatabaseExtensionRegistrar {
 
         case View(YapDB.View)
         case Filter(YapDB.Filter)
         case Search(YapDB.Search)
+        case Index(YapDB.SecondaryIndex)
 
         public var name: String {
             switch self {
             case let .View(view):       return view.name
             case let .Filter(filter):   return filter.name
             case let .Search(search):   return search.name
+            case let .Index(index):     return index.name
             }
         }
 
-        var registrar: YapDatabaseViewRegistrar {
+        var registrar: YapDatabaseExtensionRegistrar {
             switch self {
             case let .View(view):       return view
             case let .Filter(filter):   return filter
             case let .Search(search):   return search
+            case let .Index(index):     return index
             }
         }
 
@@ -77,23 +80,11 @@ extension YapDB {
 
 extension YapDB {
 
-    /**
-    The base class for other YapDatabaseView wrapper types.
-    */
-    public class BaseView {
+    public class BaseExtension {
         let name: String
         let version: String
         let collections: Set<String>?
         let persistent: Bool
-
-        var options: YapDatabaseViewOptions {
-            get {
-                let options = YapDatabaseViewOptions()
-                options.isPersistent = persistent
-                options.allowedCollections = collections.map { YapWhitelistBlacklist(whitelist: $0) }
-                return options
-            }
-        }
 
         init(name n: String, version v: String = "1.0", persistent p: Bool = true, collections c: [String]? = .None) {
             name = n
@@ -112,6 +103,21 @@ extension YapDB {
             return (database.registeredExtension(name) as? YapDatabaseView) != .None
         }
     }
+
+    /**
+    The base class for other YapDatabaseView wrapper types.
+    */
+    public class BaseView: BaseExtension {
+
+        var options: YapDatabaseViewOptions {
+            get {
+                let options = YapDatabaseViewOptions()
+                options.isPersistent = persistent
+                options.allowedCollections = collections.map { YapWhitelistBlacklist(whitelist: $0) }
+                return options
+            }
+        }
+    }
 }
 
 extension YapDB {
@@ -120,7 +126,7 @@ extension YapDB {
     A wrapper around YapDatabaseView. It can be constructed with a name, which is
     the name the extension is registered under, a grouping enum type and a sorting enum type.
     */
-    public class View: BaseView, YapDatabaseViewProducer, YapDatabaseViewRegistrar {
+    public class View: BaseView, YapDatabaseViewProducer, YapDatabaseExtensionRegistrar {
 
         /**
         An enum to make creating YapDatabaseViewGrouping easier. E.g.
@@ -211,7 +217,7 @@ extension YapDB {
     is a YapDB.Fetch type. This allows for filtering of other filters, and 
     even filtering of search results.
     */
-    public class Filter: BaseView, YapDatabaseViewProducer, YapDatabaseViewRegistrar {
+    public class Filter: BaseView, YapDatabaseViewProducer, YapDatabaseExtensionRegistrar {
 
         /**
         An enum to make creating YapDatabaseViewFiltering easier.
@@ -279,7 +285,7 @@ extension YapDB {
     In this case, the parent is a YapDB.Fetch type. This
     allows for searching of other filters, and even searching inside search results.
     */
-    public class Search: BaseView, YapDatabaseViewProducer, YapDatabaseViewRegistrar {
+    public class Search: BaseView, YapDatabaseViewProducer, YapDatabaseExtensionRegistrar {
 
         /**
         An enum to make creating YapDatabaseFullTextSearchHandler easier.
@@ -352,6 +358,75 @@ extension YapDB {
             }
         }
     }
+}
+
+
+extension YapDB {
+
+    /**
+    A wrapper around YapDatabaseSecondaryIndex.
+
+    A YapDatabaseSecondaryIndex is an extention (but not a view extension) which
+    is similar to a full text search extension. It features a handler, which must
+    be provided to update a dictionary used to index records.
+    */
+    public class SecondaryIndex: BaseExtension, YapDatabaseExtensionRegistrar {
+
+        public enum Handler {
+            case ByKey(YapDatabaseSecondaryIndexWithKeyBlock)
+            case ByObject(YapDatabaseSecondaryIndexWithObjectBlock)
+            case ByMetadata(YapDatabaseSecondaryIndexWithMetadataBlock)
+            case ByRow(YapDatabaseSecondaryIndexWithRowBlock)
+
+            public var object: YapDatabaseSecondaryIndexHandler {
+                switch self {
+                case let .ByKey(block): return YapDatabaseSecondaryIndexHandler.withKeyBlock(block)
+                case let .ByObject(block): return YapDatabaseSecondaryIndexHandler.withObjectBlock(block)
+                case let .ByMetadata(block): return YapDatabaseSecondaryIndexHandler.withMetadataBlock(block)
+                case let .ByRow(block): return YapDatabaseSecondaryIndexHandler.withRowBlock(block)
+                }
+            }
+        }
+
+        let handler: Handler
+        let columnTypes: [String: YapDatabaseSecondaryIndexType]
+
+        var options: YapDatabaseSecondaryIndexOptions {
+            get {
+                let options = YapDatabaseSecondaryIndexOptions()
+                options.allowedCollections = collections.map { YapWhitelistBlacklist(whitelist: $0) }
+                return options
+            }
+        }
+
+        public init(name n: String, handler h: Handler, columnTypes ct: [String: YapDatabaseSecondaryIndexType], version v: String, persistent p: Bool, collections c: [String]?) {
+            handler = h
+            columnTypes = ct
+            super.init(name: n, version: v, persistent: p, collections: c)
+        }
+
+        func setup() -> YapDatabaseSecondaryIndexSetup {
+            let setup = YapDatabaseSecondaryIndexSetup()
+            for (column, indexType) in columnTypes {
+                setup.addColumn(column, withType: indexType)
+            }
+            return setup
+        }
+
+        public func registerInDatabase(database: YapDatabase, withConnection connection: YapDatabaseConnection?) {
+            if !isRegisteredInDatabase(database) {
+                let secondaryIndex = YapDatabaseSecondaryIndex(setup: setup(), handler: handler.object, versionTag: version, options: options)
+                if let connection = connection {
+                    database.registerExtension(secondaryIndex, withName: name, connection: connection)
+                }
+                else {
+                    database.registerExtension(secondaryIndex, withName: name)
+                }
+            }
+        }
+    }
+
+
 }
 
 extension YapDB {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,4 +2,4 @@
 source /usr/local/opt/chruby/share/chruby/chruby.sh
 chruby ruby
 
-xcodebuild -workspace framework/YapDatabaseExtensions.xcworkspace -scheme YapDatabaseExtensions test
+xcodebuild -workspace framework/YapDatabaseExtensions.xcworkspace -scheme YapDatabaseExtensions test | xcpretty -c && exit ${PIPESTATUS[0]}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+source /usr/local/opt/chruby/share/chruby/chruby.sh
+chruby ruby
+
+xcodebuild -workspace framework/YapDatabaseExtensions.xcworkspace -scheme YapDatabaseExtensions test


### PR DESCRIPTION
Technically, this `Fetch` enum is more just a helper around registering extensions, so Fetch is perhaps not the best name now.
