### PR TITLE
Observed crash in asyncWrite in Release configuration with value types.

### DIFF
--- a/framework/YapDatabaseExtensions/BrightFutures/BrightFutures.swift
+++ b/framework/YapDatabaseExtensions/BrightFutures/BrightFutures.swift
@@ -104,7 +104,7 @@ extension YapDatabaseConnection {
     :param: value A ValueWithValueMetadata.
     :return: a Future ValueWithValueMetadata.
     */
-    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata) -> Future<ValueWithValueMetadata> {
+    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata) -> Future<ValueWithValueMetadata> {
         let promise = Promise<ValueWithValueMetadata>()
         asyncWrite(value, completion: promise.success)
         return promise.future
@@ -309,7 +309,7 @@ extension YapDatabase {
     :param: value A ValueWithValueMetadata.
     :return: a Future ValueWithValueMetadata.
     */
-    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata) -> Future<ValueWithValueMetadata> {
+    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata) -> Future<ValueWithValueMetadata> {
         let promise = Promise<ValueWithValueMetadata>()
         asyncWrite(value, completion: promise.success)
         return promise.future

--- a/framework/YapDatabaseExtensions/Common/Write.swift
+++ b/framework/YapDatabaseExtensions/Common/Write.swift
@@ -136,7 +136,7 @@ extension YapDatabaseReadWriteTransaction {
     :param: objects A SequenceType of ValueWithValueMetadata instances.
     :returns: An array of ValueWithValueMetadata instances.
     */
-    public func write<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(values: Values) -> [ValueWithValueMetadata] {
+    public func write<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(values: Values) -> [ValueWithValueMetadata] {
         return map(values, write)
     }
 
@@ -209,7 +209,7 @@ extension YapDatabaseConnection {
     :param: value A ValueWithValueMetadata.
     :returns: The ValueWithValueMetadata.
     */
-    public func write<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata) -> ValueWithValueMetadata {
+    public func write<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata) -> ValueWithValueMetadata {
         return write { $0.write(value) }
     }
 
@@ -277,7 +277,7 @@ extension YapDatabaseConnection {
     :param: queue A dispatch_queue_t, defaults to the main queue.
     :param: completion A closure which receives the ValueWithValueMetadata.
     */
-    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ValueWithValueMetadata) -> Void) {
+    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ValueWithValueMetadata) -> Void) {
         asyncWrite({ $0.write(value) }, queue: queue, completion: completion)
     }
 
@@ -341,7 +341,7 @@ extension YapDatabaseConnection {
     :param: objects A SequenceType of ValueWithValueMetadata instances.
     :returns: An array of ValueWithValueMetadata instances.
     */
-    public func write<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(values: Values) -> [ValueWithValueMetadata] {
+    public func write<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(values: Values) -> [ValueWithValueMetadata] {
         return write { $0.write(values) }
     }
 
@@ -418,7 +418,7 @@ extension YapDatabaseConnection {
     :param: objects A SequenceType of ValueWithValueMetadata instances.
     :returns: An array of ValueWithValueMetadata instances.
     */
-    public func asyncWrite<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(values: Values, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ValueWithValueMetadata]) -> Void) {
+    public func asyncWrite<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(values: Values, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ValueWithValueMetadata]) -> Void) {
         asyncWrite({ $0.write(values) }, queue: queue, completion: completion)
     }
 }
@@ -478,7 +478,7 @@ extension YapDatabase {
     :param: value A ValueWithValueMetadata.
     :returns: The ValueWithValueMetadata.
     */
-    public func write<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata) -> ValueWithValueMetadata {
+    public func write<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata) -> ValueWithValueMetadata {
         return newConnection().write(value)
     }
 
@@ -546,7 +546,7 @@ extension YapDatabase {
     :param: queue A dispatch_queue_t, defaults to the main queue.
     :param: completion A closure which receives the ValueWithValueMetadata.
     */
-    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ValueWithValueMetadata) -> Void) {
+    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ValueWithValueMetadata) -> Void) {
         newConnection().asyncWrite(value, queue: queue, completion: completion)
     }
 
@@ -610,7 +610,7 @@ extension YapDatabase {
     :param: objects A SequenceType of ValueWithValueMetadata instances.
     :returns: An array of ValueWithValueMetadata instances.
     */
-    public func write<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(values: Values) -> [ValueWithValueMetadata] {
+    public func write<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(values: Values) -> [ValueWithValueMetadata] {
         return newConnection().write(values)
     }
 
@@ -675,7 +675,7 @@ extension YapDatabase {
     :param: objects A SequenceType of ValueWithValueMetadata instances.
     :returns: An array of ValueWithValueMetadata instances.
     */
-    public func asyncWrite<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(values: Values, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ValueWithValueMetadata]) -> Void) {
+    public func asyncWrite<Values, ValueWithValueMetadata where Values: SequenceType, Values.Generator.Element == ValueWithValueMetadata, ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(values: Values, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ValueWithValueMetadata]) -> Void) {
         newConnection().asyncWrite(values, queue: queue, completion: completion)
     }
 

--- a/framework/YapDatabaseExtensions/Common/Write.swift
+++ b/framework/YapDatabaseExtensions/Common/Write.swift
@@ -49,8 +49,8 @@ extension YapDatabaseReadWriteTransaction {
     :param: object An ObjectWithValueMetadata.
     :returns: The ObjectWithValueMetadata.
     */
-    public func write<ObjectWithValueMetadata where ObjectWithValueMetadata: NSCoding, ObjectWithValueMetadata: ValueMetadataPersistable>(object: ObjectWithValueMetadata) -> ObjectWithValueMetadata {
-        writeAtIndex(indexForPersistable(object), object: object, metadata: object.metadata.archive)
+    public func write<ObjectWithValueMetadata where ObjectWithValueMetadata: NSCoding, ObjectWithValueMetadata: ValueMetadataPersistable, ObjectWithValueMetadata.MetadataType.ArchiverType.ValueType == ObjectWithValueMetadata.MetadataType>(object: ObjectWithValueMetadata) -> ObjectWithValueMetadata {
+        writeAtIndex(indexForPersistable(object), object: object, metadata: ObjectWithValueMetadata.MetadataType.ArchiverType(object.metadata))
         return object
     }
 
@@ -61,7 +61,7 @@ extension YapDatabaseReadWriteTransaction {
     :returns: The Value.
     */
     public func write<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(value: Value) -> Value {
-        writeAtIndex(indexForPersistable(value), object: value.archive)
+        writeAtIndex(indexForPersistable(value), object: Value.ArchiverType(value))
         return value
     }
 
@@ -71,8 +71,8 @@ extension YapDatabaseReadWriteTransaction {
     :param: value A ValueWithValueMetadata.
     :returns: The ValueWithValueMetadata.
     */
-    public func write<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata) -> ValueWithValueMetadata {
-        writeAtIndex(indexForPersistable(value), object: value.archive, metadata: value.metadata.archive)
+    public func write<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata) -> ValueWithValueMetadata {
+        writeAtIndex(indexForPersistable(value), object: ValueWithValueMetadata.ArchiverType(value), metadata: ValueWithValueMetadata.MetadataType.ArchiverType(value.metadata))
         return value
     }
 
@@ -83,7 +83,7 @@ extension YapDatabaseReadWriteTransaction {
     :returns: The ValueWithObjectMetadata.
     */
     public func write<ValueWithObjectMetadata where ValueWithObjectMetadata: Saveable, ValueWithObjectMetadata: ObjectMetadataPersistable, ValueWithObjectMetadata.ArchiverType.ValueType == ValueWithObjectMetadata>(value: ValueWithObjectMetadata) -> ValueWithObjectMetadata {
-        writeAtIndex(indexForPersistable(value), object: value.archive, metadata: value.metadata)
+        writeAtIndex(indexForPersistable(value), object: ValueWithObjectMetadata.ArchiverType(value), metadata: value.metadata)
         return value
     }
 }
@@ -197,7 +197,10 @@ extension YapDatabaseConnection {
     :returns: The Value.
     */
     public func write<Value where Value: Saveable, Value: Persistable, Value.ArchiverType.ValueType == Value>(value: Value) -> Value {
-        return write { $0.write(value) }
+//        return write { $0.write(value) }
+        return write { (transaction: YapDatabaseReadWriteTransaction) -> Value in
+            return transaction.write(value)
+        }
     }
 
     /**

--- a/framework/YapDatabaseExtensions/Common/YapDatabaseExtensions.swift
+++ b/framework/YapDatabaseExtensions/Common/YapDatabaseExtensions.swift
@@ -288,7 +288,7 @@ Again, primarily useful when implmementing encodeWithCoder(_: NSCoder)
 :returns: An optional ArchiverType instance.
 */
 public func archiveFromValue<Value where Value: Saveable, Value.ArchiverType.ValueType == Value>(value: Value?) -> Value.ArchiverType? {
-    return value.map { $0.archive }
+    return value.map { Value.ArchiverType($0) }
 }
 
 /**

--- a/framework/YapDatabaseExtensions/PromiseKit/PromiseKit.swift
+++ b/framework/YapDatabaseExtensions/PromiseKit/PromiseKit.swift
@@ -91,7 +91,7 @@ extension YapDatabaseConnection {
     :param: value A ValueWithValueMetadata.
     :return: a Promise Value.
     */
-    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata) -> Promise<ValueWithValueMetadata> {
+    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata) -> Promise<ValueWithValueMetadata> {
         return Promise { (fulfiller, _) in
             self.asyncWrite(value, completion: fulfiller)
         }
@@ -292,7 +292,7 @@ extension YapDatabase {
     :param: value A ValueWithValueMetadata.
     :return: a Promise Value.
     */
-    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata) -> Promise<ValueWithValueMetadata> {
+    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata) -> Promise<ValueWithValueMetadata> {
         return newConnection().asyncWrite(value)
     }
 }

--- a/framework/YapDatabaseExtensions/SwiftTask/SwiftTask.swift
+++ b/framework/YapDatabaseExtensions/SwiftTask/SwiftTask.swift
@@ -105,7 +105,7 @@ extension YapDatabaseConnection {
     :param: value A ValueWithValueMetadata.
     :return: a Task ValueWithValueMetadata.
     */
-    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata) -> Task<Void, ValueWithValueMetadata, Void> {
+    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata) -> Task<Void, ValueWithValueMetadata, Void> {
         return Task { _, fulfill, _, _ in
             self.asyncWrite(value, completion: fulfill)
         }
@@ -307,7 +307,7 @@ extension YapDatabase {
     :param: value A ValueWithValueMetadata.
     :return: a Task ValueWithValueMetadata.
     */
-    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata>(value: ValueWithValueMetadata) -> Task<Void, ValueWithValueMetadata, Void> {
+    public func asyncWrite<ValueWithValueMetadata where ValueWithValueMetadata: Saveable, ValueWithValueMetadata: ValueMetadataPersistable, ValueWithValueMetadata.ArchiverType.ValueType == ValueWithValueMetadata, ValueWithValueMetadata.MetadataType.ArchiverType.ValueType == ValueWithValueMetadata.MetadataType>(value: ValueWithValueMetadata) -> Task<Void, ValueWithValueMetadata, Void> {
         return Task { _, fulfill, _, _ in
             self.asyncWrite(value, completion: fulfill)
         }


### PR DESCRIPTION
We've observed a crash when using `connection.asyncWrite` and `connection.write` methods in the following scenario:
- Release configuration build
- Whole module optimisation off (build via CocoaPods)
- `Value` types - Objects work okay.

It looks as though inside the `write { $0.write(value) }` closure, the `value` is getting "released" somehow, or more accurately the memory storing `value` is getting overwritten?

Another possibility is that the compiler is somehow optimising away `Value.ArchiveType.ValueType == Value`. 
