### PR TITLE
Support standard YapDatabaseMappings in FetchConfiguration

### DIFF
--- a/framework/YapDatabaseExtensions.xcodeproj/xcshareddata/xcschemes/YapDatabaseExtensions.xcscheme
+++ b/framework/YapDatabaseExtensions.xcodeproj/xcshareddata/xcschemes/YapDatabaseExtensions.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/framework/YapDatabaseExtensions/Common/RemoveOperations.swift
+++ b/framework/YapDatabaseExtensions/Common/RemoveOperations.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import YapDatabase
-import Operations
 
 extension YapDatabaseConnection {
 


### PR DESCRIPTION
At the moment, `YapDB.FetchConfiguration` only allows dynamic filtering and sorting, but... if you want to use static groups, which is handy for using UILocalizedIndexedCollection, then... you can't really.
