### PR TITLE
Remove FRP module support which don't yet support Swift 2.0 in Cocoapods

### DIFF
--- a/YapDatabaseExtensions.podspec
+++ b/YapDatabaseExtensions.podspec
@@ -26,28 +26,28 @@ Pod::Spec.new do |s|
     ss.source_files   = 'YapDatabaseExtensions/Common/*.swift'    
   end
 
-  s.subspec 'PromiseKit' do |ss|
-    ss.source_files   = 'YapDatabaseExtensions/PromiseKit/*.swift'
-    ss.dependency 'YapDatabaseExtensions/Common'
-    ss.dependency 'PromiseKit/Swift/Promise', '~> 3'
-  end
+  # s.subspec 'PromiseKit' do |ss|
+  #   ss.source_files   = 'YapDatabaseExtensions/PromiseKit/*.swift'
+  #   ss.dependency 'YapDatabaseExtensions/Common'
+  #   ss.dependency 'PromiseKit/Swift/Promise', '~> 3'
+  # end
 
-  s.subspec 'BrightFutures' do |ss|
-    ss.source_files   = 'YapDatabaseExtensions/BrightFutures/*.swift'
-    ss.dependency 'YapDatabaseExtensions/Common'
-    ss.dependency 'BrightFutures', '~> 3'
-  end
+  # s.subspec 'BrightFutures' do |ss|
+  #   ss.source_files   = 'YapDatabaseExtensions/BrightFutures/*.swift'
+  #   ss.dependency 'YapDatabaseExtensions/Common'
+  #   ss.dependency 'BrightFutures', '~> 3'
+  # end
 
-  s.subspec 'SwiftTask' do |ss|
-    ss.source_files   = 'YapDatabaseExtensions/SwiftTask/*.swift'
-    ss.dependency 'YapDatabaseExtensions/Common'
-    ss.dependency 'SwiftTask', '~> 3'
-  end
+  # s.subspec 'SwiftTask' do |ss|
+  #   ss.source_files   = 'YapDatabaseExtensions/SwiftTask/*.swift'
+  #   ss.dependency 'YapDatabaseExtensions/Common'
+  #   ss.dependency 'SwiftTask', '~> 3'
+  # end
   
-  s.subspec 'All' do |ss|
-    ss.dependency 'YapDatabaseExtensions/PromiseKit'
-    ss.dependency 'YapDatabaseExtensions/BrightFutures'
-    ss.dependency 'YapDatabaseExtensions/SwiftTask'
-  end
+  # s.subspec 'All' do |ss|
+  #   ss.dependency 'YapDatabaseExtensions/PromiseKit'
+  #  ss.dependency 'YapDatabaseExtensions/BrightFutures'
+  #  ss.dependency 'YapDatabaseExtensions/SwiftTask'
+  # end
 end
 

--- a/YapDatabaseExtensions.xcodeproj/xcshareddata/xcschemes/YapDatabaseExtensions.xcscheme
+++ b/YapDatabaseExtensions.xcodeproj/xcshareddata/xcschemes/YapDatabaseExtensions.xcscheme
@@ -37,10 +37,11 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +63,18 @@
             ReferencedContainer = "container:YapDatabaseExtensions.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +89,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
I'm going to have to remove the subspec which adds SwiftTask compatible extensions until that repository publishes a Swift 2.0 version in CocoaPods.

There is a ticket for Swift 2.0: https://github.com/ReactKit/SwiftTask/issues/40, and there is a branch, so development is underway.
