### PR TITLE
Change writeOperation to use a synchronous transaction.

### DIFF
--- a/Tests/Shared/YapDatabaseExtensionsTests.swift
+++ b/Tests/Shared/YapDatabaseExtensionsTests.swift
@@ -192,12 +192,13 @@ class YapDatabaseConnectionTests: ReadWriteBaseTests {
         var didExecuteWithTransaction = false
         let operation = db.makeNewConnection().writeBlockOperation { transaction in
             didExecuteWithTransaction = true
-            expectation.fulfill()
         }
+        operation.completionBlock = { expectation.fulfill() }
 
         operationQueue.addOperation(operation)
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
+        XCTAssertTrue(operation.finished)
         XCTAssertTrue(didExecuteWithTransaction)
     }
 }

--- a/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
+++ b/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
@@ -360,11 +360,11 @@ public protocol ConnectionType {
     `YapDatabaseReadWriteTransaction`. This method is very handy for writing
     different item types to the database inside the same transaction. For example
 
-    let operation = connection.writeBlockOperation { transaction in
-    Write(people).sync(transaction)
-    Write(barcode).sync(transaction)
-    }
-    queue.addOperation(operation)
+        let operation = connection.writeBlockOperation { transaction in
+            people.write.on(transaction)
+            barcode.write.on(transaction)
+        }
+        queue.addOperation(operation)
 
     - parameter block: a closure of type (YapDatabaseReadWriteTransaction) -> Void
     - returns: an `NSOperation`.
@@ -516,17 +516,17 @@ extension YapDatabaseConnection: ConnectionType {
     `YapDatabaseReadWriteTransaction`. This method is very handy for writing
     different item types to the database inside the same transaction. For example
 
-    let operation = connection.writeBlockOperation { transaction in
-    Write(people).sync(transaction)
-    Write(barcode).sync(transaction)
-    }
-    queue.addOperation(operation)
+        let operation = connection.writeBlockOperation { transaction in
+            people.write.on(transaction)
+            barcode.write.on(transaction)
+        }
+        queue.addOperation(operation)
 
     - parameter block: a closure of type (YapDatabaseReadWriteTransaction) -> Void
     - returns: an `NSOperation`.
     */
     public func writeBlockOperation(block: (YapDatabaseReadWriteTransaction) -> Void) -> NSOperation {
-        return NSBlockOperation { self.asyncReadWriteWithBlock(block) }
+        return NSBlockOperation { self.readWriteWithBlock(block) }
     }
 }
 


### PR DESCRIPTION
Currently it's an async operation. This is not exactly a bug, but it's pretty odd subtle behavior, so it might as well be.

You take a write block, which executes asynchronously, and it gets wrapped in a `NSBlockOperation`. Therefore, the operation finishes immediately, which is almost certainly not the expected behavior.
