### PR TITLE
Code comments still refer to Saveable in a few places

### DIFF
--- a/Tests/Shared/Models.swift
+++ b/Tests/Shared/Models.swift
@@ -194,7 +194,7 @@ extension Manager: MetadataPersistable {
 }
 
 
-// MARK: - Saveable
+// MARK: - ValueCoding
 
 extension Barcode: ValueCoding {
     public typealias Coder = BarcodeCoder
@@ -230,7 +230,7 @@ extension Manager.Metadata: ValueCoding {
 }
 
 
-// MARK: - Archivers
+// MARK: - Coders
 
 public class BarcodeCoder: NSObject, NSCoding, CodingType {
     public let value: Barcode

--- a/Tests/Shared/YapDatabaseExtensionsTests.swift
+++ b/Tests/Shared/YapDatabaseExtensionsTests.swift
@@ -203,7 +203,7 @@ class YapDatabaseConnectionTests: ReadWriteBaseTests {
     }
 }
 
-class SaveableTests: XCTestCase {
+class ValueCodingTests: XCTestCase {
 
     var item: Product!
     var index: YapDB.Index!
@@ -271,7 +271,7 @@ class SaveableTests: XCTestCase {
         XCTAssertEqual(byHashes.count, items.count)
     }
 
-    func test__index_is_saveable() {
+    func test__index_is_codable() {
         let db = YapDB.testDatabase()
         db.makeNewConnection().readWriteWithBlock { transaction in
             transaction.setObject(self.index.encoded, forKey: "test-index", inCollection: "test-index-collection")

--- a/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
+++ b/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
@@ -238,7 +238,7 @@ extension Persistable {
 A generic protocol for Persistable which support YapDatabase metadata.
 
 In order to read/write your metadata types from/to YapDatabase they must
-implement either NSCoding (i.e. be object based) or Saveable (i.e. be 
+implement either NSCoding (i.e. be object based) or ValueCoding (i.e. be
 value based).
 */
 public protocol MetadataPersistable: Persistable {
@@ -555,13 +555,13 @@ public func == (a: YapDB.Index, b: YapDB.Index) -> Bool {
     return (a.collection == b.collection) && (a.key == b.key)
 }
 
-// MARK: Saveable
+// MARK: ValueCoding
 
 extension YapDB.Index: ValueCoding {
     public typealias Coder = YapDBIndexCoder
 }
 
-// MARK: Archivers
+// MARK: Coders
 
 public final class YapDBIndexCoder: NSObject, NSCoding, CodingType {
     public let value: YapDB.Index


### PR DESCRIPTION
YapDatabaseExtensions.swift was where I found a couple, but thought it'd be a good idea to flag it in an issue and do a search through the rest of the files when someone gets a chance.
