### PR TITLE
Merging MetadataPersistable into Persistable

### DIFF
--- a/Tests/Shared/Models.swift
+++ b/Tests/Shared/Models.swift
@@ -158,14 +158,14 @@ extension Product.Category: Persistable {
     }
 }
 
-extension Product: MetadataPersistable {
+extension Product: Persistable {
 
     public static var collection: String {
         return "Products"
     }
 }
 
-extension Inventory: MetadataPersistable {
+extension Inventory: Persistable {
 
     public static var collection: String {
         return "Inventory"
@@ -179,14 +179,14 @@ extension Person: Persistable {
     }
 }
 
-extension Employee: MetadataPersistable {
+extension Employee: Persistable {
 
     public static var collection: String {
         return "Employees"
     }
 }
 
-extension Manager: MetadataPersistable {
+extension Manager: Persistable {
 
     public static var collection: String {
         return "Managers"

--- a/Tests/Shared/ObjectWithNoMetadataTests.swift
+++ b/Tests/Shared/ObjectWithNoMetadataTests.swift
@@ -177,33 +177,30 @@ class ObjectWithNoMetadataTests: XCTestCase {
     func test__reader__in_transaction_at_index() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, atIndex: index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, atIndex: index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_at_index_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let atIndex = reader.inTransactionAtIndex(readTransaction)
-        guard let item = atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_index_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.atIndexInTransaction(index)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
@@ -224,33 +221,30 @@ class ObjectWithNoMetadataTests: XCTestCase {
     func test__reader__in_transaction_by_key() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, byKey: key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, atIndex: index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_by_key_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let byKey = reader.inTransactionByKey(readTransaction)
-        guard let item = byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_key_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.byKeyInTransaction(key)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
@@ -282,11 +276,10 @@ class ObjectWithNoMetadataTests: XCTestCase {
     func test__reader_with_transaction__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, atIndex: index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
@@ -314,11 +307,10 @@ class ObjectWithNoMetadataTests: XCTestCase {
     func test__reader_with_transaction__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, atIndex: index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
@@ -374,12 +366,11 @@ class ObjectWithNoMetadataTests: XCTestCase {
     func test__reader_with_connection__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
@@ -410,12 +401,11 @@ class ObjectWithNoMetadataTests: XCTestCase {
     func test__reader_with_connection__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {

--- a/Tests/Shared/ObjectWithNoMetadataTests.swift
+++ b/Tests/Shared/ObjectWithNoMetadataTests.swift
@@ -471,5 +471,173 @@ class ObjectWithNoMetadataTests: XCTestCase {
         XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
+
+    // Functional API - ReadTransactionType - Reading
+
+    func test__transaction__read_at_index_with_data() {
+        configureForReadingSingle()
+        let person: Person? = readTransaction.readAtIndex(index)
+        XCTAssertNotNil(person)
+        XCTAssertEqual(person!.identifier, item.identifier)
+        XCTAssertNil(person!.metadata)
+    }
+
+    func test__transaction__read_at_index_without_data() {
+        let person: Person? = readTransaction.readAtIndex(index)
+        XCTAssertNil(person)
+    }
+
+    func test__transaction__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let people: [Person] = readTransaction.readAtIndexes(indexes)
+        XCTAssertEqual(people.count, items.count)
+    }
+
+    func test__transaction__read_at_indexes_without_data() {
+        let people: [Person] = readTransaction.readAtIndexes(indexes)
+        XCTAssertNotNil(people)
+        XCTAssertTrue(people.isEmpty)
+    }
+
+    func test__transaction__read_by_key_with_data() {
+        configureForReadingSingle()
+        let person: Person? = readTransaction.readByKey(key)
+        XCTAssertNotNil(person)
+        XCTAssertEqual(person!.identifier, item.identifier)
+        XCTAssertNil(person!.metadata)
+    }
+
+    func test__transaction__read_by_key_without_data() {
+        let person: Person? = readTransaction.readByKey(key)
+        XCTAssertNil(person)
+    }
+
+    func test__transaction__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let people: [Person] = readTransaction.readByKeys(keys)
+        XCTAssertEqual(people.count, items.count)
+    }
+
+    func test__transaction__read_by_keys_without_data() {
+        let people: [Person] = readTransaction.readByKeys(keys)
+        XCTAssertNotNil(people)
+        XCTAssertTrue(people.isEmpty)
+    }
+
+    // Functional API - ConnectionType - Reading
+
+    func test__connection__read_at_index_with_data() {
+        configureForReadingSingle()
+        let person: Person? = connection.readAtIndex(index)
+        XCTAssertNotNil(person)
+        XCTAssertEqual(person!.identifier, item.identifier)
+        XCTAssertNil(person!.metadata)
+    }
+
+    func test__connection__read_at_index_without_data() {
+        let person: Person? = connection.readAtIndex(index)
+        XCTAssertNil(person)
+    }
+
+    func test__connection__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let people: [Person] = connection.readAtIndexes(indexes)
+        XCTAssertEqual(people.count, items.count)
+    }
+
+    func test__connection__read_at_indexes_without_data() {
+        let people: [Person] = connection.readAtIndexes(indexes)
+        XCTAssertNotNil(people)
+        XCTAssertTrue(people.isEmpty)
+    }
+
+    func test__connection__read_by_key_with_data() {
+        configureForReadingSingle()
+        let person: Person? = connection.readByKey(key)
+        XCTAssertNotNil(person)
+        XCTAssertEqual(person!.identifier, item.identifier)
+        XCTAssertNil(person!.metadata)
+    }
+
+    func test__connection__read_by_key_without_data() {
+        let person: Person? = connection.readByKey(key)
+        XCTAssertNil(person)
+    }
+
+    func test__connection__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let people: [Person] = connection.readByKeys(keys)
+        XCTAssertEqual(people.count, items.count)
+    }
+
+    func test__connection__read_by_keys_without_data() {
+        let people: [Person] = connection.readByKeys(keys)
+        XCTAssertNotNil(people)
+        XCTAssertTrue(people.isEmpty)
+    }
+
+    // MARK: - Functional API - Transaction - Writing
+
+    func test__transaction__write_item() {
+        writeTransaction.write(item)
+
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].1.identifier, item.identifier)
+        XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
+    }
+
+    func test__transaction__write_items() {
+        writeTransaction.write(items)
+
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.0.key }.sort(), indexes.map { $0.key }.sort())
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.2 }.count, items.count)
+    }
+
+    // Functional API - Connection - Writing
+
+    func test__connection__write_item() {
+        connection.write(item)
+
+        XCTAssertTrue(connection.didWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].1.identifier, item.identifier)
+        XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
+    }
+
+    func test__connection__write_items() {
+        connection.write(items)
+
+        XCTAssertTrue(connection.didWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.0.key }.sort(), indexes.map { $0.key }.sort())
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.2 }.count, items.count)
+    }
+
+    func test__connection__async_write_item() {
+        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        connection.asyncWrite(item) { expectation.fulfill() }
+
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+        XCTAssertTrue(connection.didAsyncWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].1.identifier, item.identifier)
+        XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
+    }
+
+    func test__connection__async_write_items() {
+        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        connection.asyncWrite(items) { expectation.fulfill() }
+
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+        XCTAssertTrue(connection.didAsyncWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.0.key }.sort(), indexes.map { $0.key }.sort())
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.2 }.count, items.count)
+    }
+
 }
 

--- a/Tests/Shared/ObjectWithNoMetadataTests.swift
+++ b/Tests/Shared/ObjectWithNoMetadataTests.swift
@@ -91,6 +91,15 @@ class ObjectWithNoMetadataTests: XCTestCase {
 
     // MARK: Tests
 
+    func test__metadata_is_nil() {
+        XCTAssertNil(item.metadata)
+    }
+
+    func test__metadata_cannot_be_set() {
+        item.metadata = Void()
+        XCTAssertNil(item.metadata)
+    }
+
     // Writing
 
     func test__writer_initializes_with_single_item() {

--- a/Tests/Shared/ObjectWithObjectMetadataTests.swift
+++ b/Tests/Shared/ObjectWithObjectMetadataTests.swift
@@ -84,10 +84,12 @@ class ObjectWithObjectMetadataTests: XCTestCase {
 
     func configureForReadingSingle() {
         readTransaction.object = item
+        readTransaction.metadata = item.metadata
     }
 
     func configureForReadingMultiple() {
         readTransaction.objects = items
+        readTransaction.metadatas = items.map { $0.metadata }
         readTransaction.keys = keys
     }
 
@@ -170,104 +172,113 @@ class ObjectWithObjectMetadataTests: XCTestCase {
     func test__reader__in_transaction_at_index() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, atIndex: index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, atIndex: index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__in_transaction_at_index_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let atIndex = reader.inTransactionAtIndex(readTransaction)
-        guard let item = atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__at_index_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.atIndexInTransaction(index)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__at_indexes_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader__in_transaction_by_key() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, byKey: key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, byKey: key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__in_transaction_by_key_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let byKey = reader.inTransactionByKey(readTransaction)
-        guard let item = byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__by_key_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.byKeyInTransaction(key)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_items_with_no_keys() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction()(readTransaction)
+        let result = reader.byKeysInTransaction()(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(readTransaction.didKeysInCollection!, Employee.collection)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     // Reading - With Transaction
@@ -275,90 +286,95 @@ class ObjectWithObjectMetadataTests: XCTestCase {
     func test__reader_with_transaction__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__at_indexes_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__by_keys_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__all_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Employee.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__all_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Employee.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__filter() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        let (items, missing) = reader.filterExisting(keys)
+        let (result, missing) = reader.filterExisting(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
-        XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes.first!, indexes.first!)
+        XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
@@ -367,101 +383,107 @@ class ObjectWithObjectMetadataTests: XCTestCase {
     func test__reader_with_connection__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
         reader = Read(connection)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__at_indexes_with_no_items() {
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {
         reader = Read(connection)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__by_keys_with_no_items() {
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__all_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Employee.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__all_with_no_items() {
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Employee.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__filter() {
         configureForReadingSingle()
         reader = Read(connection)
-        let (items, missing) = reader.filterExisting(keys)
+        let (result, missing) = reader.filterExisting(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
-        XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes.first!, indexes.first!)
+        XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
@@ -472,6 +494,7 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         let employee: Employee? = readTransaction.readAtIndex(index)
         XCTAssertNotNil(employee)
         XCTAssertEqual(employee!.identifier, item.identifier)
+        XCTAssertEqual(employee!.metadata, item.metadata)
     }
 
     func test__transaction__read_at_index_without_data() {
@@ -496,6 +519,7 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         let employee: Employee? = readTransaction.readByKey(key)
         XCTAssertNotNil(employee)
         XCTAssertEqual(employee!.identifier, item.identifier)
+        XCTAssertEqual(employee!.metadata, item.metadata)
     }
 
     func test__transaction__read_by_key_without_data() {
@@ -522,6 +546,7 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         let employee: Employee? = connection.readAtIndex(index)
         XCTAssertNotNil(employee)
         XCTAssertEqual(employee!.identifier, item.identifier)
+        XCTAssertEqual(employee!.metadata, item.metadata)
     }
 
     func test__connection__read_at_index_without_data() {
@@ -546,6 +571,7 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         let employee: Employee? = connection.readByKey(key)
         XCTAssertNotNil(employee)
         XCTAssertEqual(employee!.identifier, item.identifier)
+        XCTAssertEqual(employee!.metadata, item.metadata)
     }
 
     func test__connection__read_by_key_without_data() {

--- a/Tests/Shared/ObjectWithValueMetadataTests.swift
+++ b/Tests/Shared/ObjectWithValueMetadataTests.swift
@@ -170,104 +170,98 @@ class ObjectWithValueMetadataTests: XCTestCase {
     func test__reader__in_transaction_at_index() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, atIndex: index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, atIndex: index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_at_index_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let atIndex = reader.inTransactionAtIndex(readTransaction)
-        guard let item = atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_index_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.atIndexInTransaction(index)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__at_indexes_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader__in_transaction_by_key() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, byKey: key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, byKey: key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_by_key_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let byKey = reader.inTransactionByKey(readTransaction)
-        guard let item = byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_key_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.byKeyInTransaction(key)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_items_with_no_keys() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction()(readTransaction)
+        let result = reader.byKeysInTransaction()(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
         XCTAssertEqual(readTransaction.didKeysInCollection!, Manager.collection)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     // Reading - With Transaction
@@ -275,90 +269,88 @@ class ObjectWithValueMetadataTests: XCTestCase {
     func test__reader_with_transaction__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__at_indexes_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__by_keys_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__all_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Manager.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__all_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Manager.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__filter() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        let (items, missing) = reader.filterExisting(keys)
+        let (result, missing) = reader.filterExisting(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
-        XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
@@ -367,101 +359,99 @@ class ObjectWithValueMetadataTests: XCTestCase {
     func test__reader_with_connection__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
         reader = Read(connection)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__at_indexes_with_no_items() {
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {
         reader = Read(connection)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__by_keys_with_no_items() {
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__all_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Manager.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__all_with_no_items() {
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Manager.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__filter() {
         configureForReadingSingle()
         reader = Read(connection)
-        let (items, missing) = reader.filterExisting(keys)
+        let (result, missing) = reader.filterExisting(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
-        XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 

--- a/Tests/Shared/ObjectWithValueMetadataTests.swift
+++ b/Tests/Shared/ObjectWithValueMetadataTests.swift
@@ -174,7 +174,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__in_transaction_at_index_2() {
@@ -185,7 +185,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__at_index_in_transaction() {
@@ -196,7 +196,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
@@ -221,7 +221,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__in_transaction_by_key_2() {
@@ -232,7 +232,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__by_key_in_transaction() {
@@ -243,7 +243,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
@@ -279,7 +279,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
@@ -311,7 +311,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
@@ -372,7 +372,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
         }
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
@@ -408,7 +408,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
         }
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {

--- a/Tests/Shared/Support.swift
+++ b/Tests/Shared/Support.swift
@@ -28,43 +28,21 @@ class TestableReadTransaction {
 
     var didReadAtIndex: YapDB.Index? {
         get { return didReadAtIndexes.first }
-        set {
-            if let newIndex = newValue {
-                didReadAtIndexes = [newIndex]
-            }
-            else {
-                didReadAtIndexes = []
-            }
-        }
     }
 
     var metadata: AnyObject? {
-        get { return metadatas.first }
-        set {
-            if let newObject = newValue {
-                metadatas = [newObject]
-            }
-            else {
-                metadatas = []
-            }
-        }
+        get { return metadatas[0] }
+        set { metadatas = [newValue] }
     }
 
     var didReadMetadataAtIndex: YapDB.Index? {
         get { return didReadMetadataAtIndexes.first }
-        set {
-            if let newIndex = newValue {
-                didReadMetadataAtIndexes = [newIndex]
-            }
-            else {
-                didReadMetadataAtIndexes = []
-            }
-        }
     }
 
     var currentReadIndex = 0
     var objects: [AnyObject] = []
-    var metadatas: [AnyObject] = []
+    var currentMetadataReadIndex = 0
+    var metadatas: [AnyObject?] = []
     var didReadAtIndexes: [YapDB.Index] = []
     var didReadMetadataAtIndexes: [YapDB.Index] = []
 
@@ -79,9 +57,9 @@ class TestableReadTransaction {
     }
 
     func getNextMetadata() -> AnyObject? {
-        if metadatas.endIndex > currentReadIndex {
-            let object = metadatas[currentReadIndex]
-            currentReadIndex += 1
+        if metadatas.endIndex > currentMetadataReadIndex {
+            let object = metadatas[currentMetadataReadIndex]
+            currentMetadataReadIndex += 1
             return object
         }
         return .None

--- a/Tests/Shared/ValueWithNoMetadataTests.swift
+++ b/Tests/Shared/ValueWithNoMetadataTests.swift
@@ -92,6 +92,15 @@ class ValueWithNoMetadataTests: XCTestCase {
 
     // MARK: Tests
 
+    func test__metadata_is_nil() {
+        XCTAssertNil(item.metadata)
+    }
+
+    func test__metadata_cannot_be_set() {
+        item.metadata = Void()
+        XCTAssertNil(item.metadata)
+    }
+
     // Writing
 
     func test__writer_initializes_with_single_item() {
@@ -463,6 +472,175 @@ class ValueWithNoMetadataTests: XCTestCase {
         XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
+
+    // Functional API - ReadTransactionType - Reading
+
+    func test__transaction__read_at_index_with_data() {
+        configureForReadingSingle()
+        let barcode: Barcode? = readTransaction.readAtIndex(index)
+        XCTAssertNotNil(barcode)
+        XCTAssertEqual(barcode!.identifier, item.identifier)
+        XCTAssertNil(barcode!.metadata)
+    }
+
+    func test__transaction__read_at_index_without_data() {
+        let barcode: Barcode? = readTransaction.readAtIndex(index)
+        XCTAssertNil(barcode)
+    }
+
+    func test__transaction__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let barcodes: [Barcode] = readTransaction.readAtIndexes(indexes)
+        XCTAssertEqual(barcodes.count, items.count)
+    }
+
+    func test__transaction__read_at_indexes_without_data() {
+        let barcodes: [Barcode] = readTransaction.readAtIndexes(indexes)
+        XCTAssertNotNil(barcodes)
+        XCTAssertTrue(barcodes.isEmpty)
+    }
+
+    func test__transaction__read_by_key_with_data() {
+        configureForReadingSingle()
+        let barcode: Barcode? = readTransaction.readByKey(key)
+        XCTAssertNotNil(barcode)
+        XCTAssertEqual(barcode!.identifier, item.identifier)
+        XCTAssertNil(barcode!.metadata)
+    }
+
+    func test__transaction__read_by_key_without_data() {
+        let barcode: Barcode? = readTransaction.readByKey(key)
+        XCTAssertNil(barcode)
+    }
+
+    func test__transaction__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let barcodes: [Barcode] = readTransaction.readByKeys(keys)
+        XCTAssertEqual(barcodes.count, items.count)
+    }
+
+    func test__transaction__read_by_keys_without_data() {
+        let barcodes: [Barcode] = readTransaction.readByKeys(keys)
+        XCTAssertNotNil(barcodes)
+        XCTAssertTrue(barcodes.isEmpty)
+    }
+
+    // Functional API - ConnectionType - Reading
+
+    func test__connection__read_at_index_with_data() {
+        configureForReadingSingle()
+        let barcode: Barcode? = connection.readAtIndex(index)
+        XCTAssertNotNil(barcode)
+        XCTAssertEqual(barcode!.identifier, item.identifier)
+        XCTAssertNil(barcode!.metadata)
+    }
+
+    func test__connection__read_at_index_without_data() {
+        let barcode: Barcode? = connection.readAtIndex(index)
+        XCTAssertNil(barcode)
+    }
+
+    func test__connection__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let barcodes: [Barcode] = connection.readAtIndexes(indexes)
+        XCTAssertEqual(barcodes.count, items.count)
+    }
+
+    func test__connection__read_at_indexes_without_data() {
+        let barcodes: [Barcode] = connection.readAtIndexes(indexes)
+        XCTAssertNotNil(barcodes)
+        XCTAssertTrue(barcodes.isEmpty)
+    }
+
+    func test__connection__read_by_key_with_data() {
+        configureForReadingSingle()
+        let barcode: Barcode? = connection.readByKey(key)
+        XCTAssertNotNil(barcode)
+        XCTAssertEqual(barcode!.identifier, item.identifier)
+        XCTAssertNil(barcode!.metadata)
+    }
+
+    func test__connection__read_by_key_without_data() {
+        let barcode: Barcode? = connection.readByKey(key)
+        XCTAssertNil(barcode)
+    }
+
+    func test__connection__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let barcodes: [Barcode] = connection.readByKeys(keys)
+        XCTAssertEqual(barcodes.count, items.count)
+    }
+
+    func test__connection__read_by_keys_without_data() {
+        let barcodes: [Barcode] = connection.readByKeys(keys)
+        XCTAssertNotNil(barcodes)
+        XCTAssertTrue(barcodes.isEmpty)
+    }
+
+    // MARK: - Functional API - Transaction - Writing
+
+    func test__transaction__write_item() {
+        writeTransaction.write(item)
+
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
+    }
+
+    func test__transaction__write_items() {
+        writeTransaction.write(items)
+
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.0.key }.sort(), indexes.map { $0.key }.sort())
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.2 }.count, items.count)
+    }
+
+    // Functional API - Connection - Writing
+
+    func test__connection__write_item() {
+        connection.write(item)
+
+        XCTAssertTrue(connection.didWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
+    }
+
+    func test__connection__write_items() {
+        connection.write(items)
+
+        XCTAssertTrue(connection.didWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.0.key }.sort(), indexes.map { $0.key }.sort())
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.2 }.count, items.count)
+    }
+
+    func test__connection__async_write_item() {
+        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        connection.asyncWrite(item) { expectation.fulfill() }
+
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+        XCTAssertTrue(connection.didAsyncWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
+    }
+
+    func test__connection__async_write_items() {
+        let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
+        connection.asyncWrite(items) { expectation.fulfill() }
+
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+        XCTAssertTrue(connection.didAsyncWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.0.key }.sort(), indexes.map { $0.key }.sort())
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes.map { $0.2 }.count, items.count)
+    }
+
+
 
 }
 

--- a/Tests/Shared/ValueWithNoMetadataTests.swift
+++ b/Tests/Shared/ValueWithNoMetadataTests.swift
@@ -178,104 +178,98 @@ class ValueWithNoMetadataTests: XCTestCase {
     func test__reader__in_transaction_at_index() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, atIndex: index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, atIndex: index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_at_index_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let atIndex = reader.inTransactionAtIndex(readTransaction)
-        guard let item = atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_index_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.atIndexInTransaction(index)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__at_indexes_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader__in_transaction_by_key() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, byKey: key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, byKey: key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_by_key_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let byKey = reader.inTransactionByKey(readTransaction)
-        guard let item = byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_key_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.byKeyInTransaction(key)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_items_with_no_keys() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction()(readTransaction)
+        let result = reader.byKeysInTransaction()(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
         XCTAssertEqual(readTransaction.didKeysInCollection!, Barcode.collection)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     // Reading - With Transaction
@@ -283,90 +277,88 @@ class ValueWithNoMetadataTests: XCTestCase {
     func test__reader_with_transaction__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__at_indexes_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__by_keys_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__all_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Barcode.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__all_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Barcode.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__filter() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        let (items, missing) = reader.filterExisting(keys)
+        let (result, missing) = reader.filterExisting(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
-        XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
@@ -375,92 +367,90 @@ class ValueWithNoMetadataTests: XCTestCase {
     func test__reader_with_connection__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
         reader = Read(connection)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__at_indexes_with_no_items() {
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {
         reader = Read(connection)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__by_keys_with_no_items() {
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__all_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Barcode.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__all_with_no_items() {
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Barcode.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__filter() {

--- a/Tests/Shared/ValueWithObjectMetadataTests.swift
+++ b/Tests/Shared/ValueWithObjectMetadataTests.swift
@@ -194,7 +194,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__in_transaction_at_index_2() {
@@ -205,7 +205,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__at_index_in_transaction() {
@@ -216,7 +216,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
@@ -241,7 +241,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__in_transaction_by_key_2() {
@@ -252,7 +252,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__by_key_in_transaction() {
@@ -263,7 +263,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
@@ -299,7 +299,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
@@ -331,7 +331,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
@@ -392,7 +392,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         }
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
@@ -428,7 +428,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         }
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {

--- a/Tests/Shared/ValueWithObjectMetadataTests.swift
+++ b/Tests/Shared/ValueWithObjectMetadataTests.swift
@@ -190,104 +190,98 @@ class ValueWithObjectMetadataTests: XCTestCase {
     func test__reader__in_transaction_at_index() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, atIndex: index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, atIndex: index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_at_index_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let atIndex = reader.inTransactionAtIndex(readTransaction)
-        guard let item = atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_index_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.atIndexInTransaction(index)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__at_indexes_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader__in_transaction_by_key() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, byKey: key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, byKey: key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_by_key_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let byKey = reader.inTransactionByKey(readTransaction)
-        guard let item = byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_key_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.byKeyInTransaction(key)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_items_with_no_keys() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction()(readTransaction)
+        let result = reader.byKeysInTransaction()(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
         XCTAssertEqual(readTransaction.didKeysInCollection!, Inventory.collection)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     // Reading - With Transaction
@@ -295,90 +289,88 @@ class ValueWithObjectMetadataTests: XCTestCase {
     func test__reader_with_transaction__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__at_indexes_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__by_keys_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__all_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Inventory.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__all_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Inventory.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__filter() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        let (items, missing) = reader.filterExisting(keys)
+        let (result, missing) = reader.filterExisting(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
-        XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
@@ -387,104 +379,101 @@ class ValueWithObjectMetadataTests: XCTestCase {
     func test__reader_with_connection__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
         reader = Read(connection)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__at_indexes_with_no_items() {
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {
         reader = Read(connection)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__by_keys_with_no_items() {
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__all_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Inventory.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__all_with_no_items() {
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Inventory.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__filter() {
         configureForReadingSingle()
         reader = Read(connection)
-        let (items, missing) = reader.filterExisting(keys)
+        let (result, missing) = reader.filterExisting(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
-        XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
-
 
     // Functional API - ReadTransactionType - Reading
 

--- a/Tests/Shared/ValueWithValueMetadataTests.swift
+++ b/Tests/Shared/ValueWithValueMetadataTests.swift
@@ -188,33 +188,30 @@ class ValueWithValueMetadataTests: XCTestCase {
     func test__reader__in_transaction_at_index() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, atIndex: index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, atIndex: index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_at_index_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let atIndex = reader.inTransactionAtIndex(readTransaction)
-        guard let item = atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_index_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.atIndexInTransaction(index)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
@@ -227,41 +224,38 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__reader__at_indexes_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader__in_transaction_by_key() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.inTransaction(readTransaction, byKey: key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.inTransaction(readTransaction, byKey: key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__in_transaction_by_key_2() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let byKey = reader.inTransactionByKey(readTransaction)
-        guard let item = byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_key_in_transaction() {
         configureForReadingSingle()
         reader = Read(readTransaction)
         let inTransaction = reader.byKeyInTransaction(key)
-        guard let item = inTransaction(readTransaction) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = inTransaction(readTransaction)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
@@ -283,9 +277,9 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__reader__by_keys_in_transaction_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     // Reading - With Transaction
@@ -293,18 +287,17 @@ class ValueWithValueMetadataTests: XCTestCase {
     func test__reader_with_transaction__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__at_indexes_with_items() {
@@ -317,26 +310,25 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__reader_with_transaction__at_indexes_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
         reader = Read(readTransaction)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_transaction__by_keys_with_items() {
@@ -349,9 +341,9 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__reader_with_transaction__by_keys_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__all_with_items() {
@@ -365,10 +357,10 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__reader_with_transaction__all_with_no_items() {
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Product.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_transaction__filter() {
@@ -385,20 +377,19 @@ class ValueWithValueMetadataTests: XCTestCase {
     func test__reader_with_connection__at_index_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.atIndex(index) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.atIndex(index)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
         reader = Read(connection)
-        let item = reader.atIndex(index)
+        let result = reader.atIndex(index)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__at_indexes_with_items() {
@@ -412,29 +403,28 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__reader_with_connection__at_indexes_with_no_items() {
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
-        guard let item = reader.byKey(key) else {
-            XCTFail("Expecting to have an item"); return
-        }
+        let result = reader.byKey(key)
+        XCTAssertNotNil(result)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, self.item.identifier)
+        XCTAssertEqual(result!.identifier, item.identifier)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {
         reader = Read(connection)
-        let item = reader.byKey(key)
+        let result = reader.byKey(key)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertNil(item)
+        XCTAssertNil(result)
     }
 
     func test__reader_with_connection__by_keys_with_items() {
@@ -448,10 +438,10 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__reader_with_connection__by_keys_with_no_items() {
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__all_with_items() {
@@ -466,11 +456,11 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__reader_with_connection__all_with_no_items() {
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Product.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
-        XCTAssertEqual(items, [])
+        XCTAssertEqual(result, [])
     }
 
     func test__reader_with_connection__filter() {

--- a/Tests/Shared/ValueWithValueMetadataTests.swift
+++ b/Tests/Shared/ValueWithValueMetadataTests.swift
@@ -192,7 +192,7 @@ class ValueWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__in_transaction_at_index_2() {
@@ -203,7 +203,7 @@ class ValueWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__at_index_in_transaction() {
@@ -214,7 +214,7 @@ class ValueWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
@@ -239,7 +239,7 @@ class ValueWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__in_transaction_by_key_2() {
@@ -250,7 +250,7 @@ class ValueWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__by_key_in_transaction() {
@@ -261,7 +261,7 @@ class ValueWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
@@ -297,7 +297,7 @@ class ValueWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
@@ -329,7 +329,7 @@ class ValueWithValueMetadataTests: XCTestCase {
             XCTFail("Expecting to have an item"); return
         }
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
@@ -390,7 +390,7 @@ class ValueWithValueMetadataTests: XCTestCase {
         }
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
@@ -426,7 +426,7 @@ class ValueWithValueMetadataTests: XCTestCase {
         }
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
-        XCTAssertEqual(item.identifier, item.identifier)
+        XCTAssertEqual(item.identifier, self.item.identifier)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {

--- a/YapDatabaseExtensions.xcodeproj/project.pbxproj
+++ b/YapDatabaseExtensions.xcodeproj/project.pbxproj
@@ -61,6 +61,12 @@
 		65C557A41BCB26010065C96A /* Write.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5578A1BCB26010065C96A /* Write.swift */; settings = {ASSET_TAGS = (); }; };
 		65C557A61BCB26310065C96A /* Functional_Remove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557A51BCB26310065C96A /* Functional_Remove.swift */; settings = {ASSET_TAGS = (); }; };
 		65C557A71BCB26310065C96A /* Functional_Remove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557A51BCB26310065C96A /* Functional_Remove.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB401BCD24AF002F2C05 /* ObjectWithNoMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04911BC9820A00AC98FD /* ObjectWithNoMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB411BCD24AF002F2C05 /* ObjectWithNoMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04911BC9820A00AC98FD /* ObjectWithNoMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB421BCD24EA002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557821BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB431BCD24EB002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557821BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB441BCD24FA002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557851BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB451BCD24FB002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557851BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		AC8FC0BC100A1A0A60C3B18F /* Pods_YapDatabaseExtensions_OSXTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574741755E625D8A78119A8A /* Pods_YapDatabaseExtensions_OSXTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -642,6 +648,8 @@
 				65C557A61BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579B1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
 				65C5579D1BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift in Sources */,
+				65C8DB441BCD24FA002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */,
+				65C8DB421BCD24EA002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */,
 				65C557A31BCB26010065C96A /* Write.swift in Sources */,
 				65C557911BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
 				65C5578F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
@@ -665,6 +673,7 @@
 				653B04B21BC9824000AC98FD /* ValueWithObjectMetadataTests.swift in Sources */,
 				653B04B41BC9824000AC98FD /* YapDatabaseExtensionsTests.swift in Sources */,
 				653B04B01BC9824000AC98FD /* Support.swift in Sources */,
+				65C8DB401BCD24AF002F2C05 /* ObjectWithNoMetadataTests.swift in Sources */,
 				653B04AA1BC9824000AC98FD /* Models.swift in Sources */,
 				653B04B31BC9824000AC98FD /* ValueWithValueMetadataTests.swift in Sources */,
 				653B04AE1BC9824000AC98FD /* ReadWriteTests.swift in Sources */,
@@ -679,6 +688,8 @@
 				65C557A71BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579C1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
 				65C5579E1BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift in Sources */,
+				65C8DB451BCD24FB002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */,
+				65C8DB431BCD24EB002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */,
 				65C557A41BCB26010065C96A /* Write.swift in Sources */,
 				65C557921BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
 				65C557901BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
@@ -702,6 +713,7 @@
 				653B04BE1BC9824100AC98FD /* ValueWithObjectMetadataTests.swift in Sources */,
 				653B04C01BC9824100AC98FD /* YapDatabaseExtensionsTests.swift in Sources */,
 				653B04BC1BC9824100AC98FD /* Support.swift in Sources */,
+				65C8DB411BCD24AF002F2C05 /* ObjectWithNoMetadataTests.swift in Sources */,
 				653B04B61BC9824100AC98FD /* Models.swift in Sources */,
 				653B04BF1BC9824100AC98FD /* ValueWithValueMetadataTests.swift in Sources */,
 				653B04BA1BC9824100AC98FD /* ReadWriteTests.swift in Sources */,

--- a/YapDatabaseExtensions.xcodeproj/project.pbxproj
+++ b/YapDatabaseExtensions.xcodeproj/project.pbxproj
@@ -67,6 +67,12 @@
 		65C8DB431BCD24EB002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557821BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C8DB441BCD24FA002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557851BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C8DB451BCD24FB002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557851BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB461BCD25E2002F2C05 /* ValueWithNoMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04971BC9820A00AC98FD /* ValueWithNoMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB471BCD25E3002F2C05 /* ValueWithNoMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04971BC9820A00AC98FD /* ValueWithNoMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB491BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C8DB481BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB4A1BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C8DB481BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB4C1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C8DB4B1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		65C8DB4D1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C8DB4B1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		AC8FC0BC100A1A0A60C3B18F /* Pods_YapDatabaseExtensions_OSXTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574741755E625D8A78119A8A /* Pods_YapDatabaseExtensions_OSXTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -128,6 +134,8 @@
 		65C557891BCB26010065C96A /* Remove.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Remove.swift; sourceTree = "<group>"; };
 		65C5578A1BCB26010065C96A /* Write.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Write.swift; sourceTree = "<group>"; };
 		65C557A51BCB26310065C96A /* Functional_Remove.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_Remove.swift; sourceTree = "<group>"; };
+		65C8DB481BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ObjectWithNoMetadata.swift; sourceTree = "<group>"; };
+		65C8DB4B1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ValueWithNoMetadata.swift; sourceTree = "<group>"; };
 		9D7D405FE2B19AF9F31FA60A /* Pods-YapDatabaseExtensions-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YapDatabaseExtensions-iOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-YapDatabaseExtensions-iOSTests/Pods-YapDatabaseExtensions-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		B26F7704368F3FE50A228AB0 /* Pods-YapDatabaseExtensions-OSX.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YapDatabaseExtensions-OSX.debug.xcconfig"; path = "Pods/Target Support Files/Pods-YapDatabaseExtensions-OSX/Pods-YapDatabaseExtensions-OSX.debug.xcconfig"; sourceTree = "<group>"; };
 		D13C45EFF8EA26355D7BE26C /* Pods-YapDatabaseExtensions-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YapDatabaseExtensions-OSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-YapDatabaseExtensions-OSX/Pods-YapDatabaseExtensions-OSX.release.xcconfig"; sourceTree = "<group>"; };
@@ -257,11 +265,13 @@
 		65C5577C1BCB26010065C96A /* Functional */ = {
 			isa = PBXGroup;
 			children = (
+				65C8DB481BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift */,
 				65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */,
 				65C5577E1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift */,
+				65C557A51BCB26310065C96A /* Functional_Remove.swift */,
+				65C8DB4B1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift */,
 				65C5577F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift */,
 				65C557801BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift */,
-				65C557A51BCB26310065C96A /* Functional_Remove.swift */,
 			);
 			path = Functional;
 			sourceTree = "<group>";
@@ -649,6 +659,8 @@
 				65C5579B1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
 				65C5579D1BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift in Sources */,
 				65C8DB441BCD24FA002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */,
+				65C8DB491BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift in Sources */,
+				65C8DB4C1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift in Sources */,
 				65C8DB421BCD24EA002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */,
 				65C557A31BCB26010065C96A /* Write.swift in Sources */,
 				65C557911BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
@@ -668,6 +680,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				653B04AF1BC9824000AC98FD /* RemovalTests.swift in Sources */,
+				65C8DB461BCD25E2002F2C05 /* ValueWithNoMetadataTests.swift in Sources */,
 				653B04AC1BC9824000AC98FD /* ObjectWithObjectMetadataTests.swift in Sources */,
 				653B04AD1BC9824000AC98FD /* ObjectWithValueMetadataTests.swift in Sources */,
 				653B04B21BC9824000AC98FD /* ValueWithObjectMetadataTests.swift in Sources */,
@@ -689,6 +702,8 @@
 				65C5579C1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
 				65C5579E1BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift in Sources */,
 				65C8DB451BCD24FB002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */,
+				65C8DB4A1BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift in Sources */,
+				65C8DB4D1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift in Sources */,
 				65C8DB431BCD24EB002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */,
 				65C557A41BCB26010065C96A /* Write.swift in Sources */,
 				65C557921BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
@@ -708,6 +723,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				653B04BB1BC9824100AC98FD /* RemovalTests.swift in Sources */,
+				65C8DB471BCD25E3002F2C05 /* ValueWithNoMetadataTests.swift in Sources */,
 				653B04B81BC9824100AC98FD /* ObjectWithObjectMetadataTests.swift in Sources */,
 				653B04B91BC9824100AC98FD /* ObjectWithValueMetadataTests.swift in Sources */,
 				653B04BE1BC9824100AC98FD /* ValueWithObjectMetadataTests.swift in Sources */,

--- a/YapDatabaseExtensions.xcodeproj/project.pbxproj
+++ b/YapDatabaseExtensions.xcodeproj/project.pbxproj
@@ -19,24 +19,20 @@
 		653B048B1BC981D700AC98FD /* YapDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04811BC981D100AC98FD /* YapDB.swift */; settings = {ASSET_TAGS = (); }; };
 		653B049B1BC9820A00AC98FD /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 653B048D1BC9820A00AC98FD /* Info.plist */; settings = {ASSET_TAGS = (); }; };
 		653B04AA1BC9824000AC98FD /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04901BC9820A00AC98FD /* Models.swift */; settings = {ASSET_TAGS = (); }; };
-		653B04AB1BC9824000AC98FD /* ObjectWithNoMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04911BC9820A00AC98FD /* ObjectWithNoMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04AC1BC9824000AC98FD /* ObjectWithObjectMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04921BC9820A00AC98FD /* ObjectWithObjectMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04AD1BC9824000AC98FD /* ObjectWithValueMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04931BC9820A00AC98FD /* ObjectWithValueMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04AE1BC9824000AC98FD /* ReadWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04941BC9820A00AC98FD /* ReadWriteTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04AF1BC9824000AC98FD /* RemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04951BC9820A00AC98FD /* RemovalTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04B01BC9824000AC98FD /* Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04961BC9820A00AC98FD /* Support.swift */; settings = {ASSET_TAGS = (); }; };
-		653B04B11BC9824000AC98FD /* ValueWithNoMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04971BC9820A00AC98FD /* ValueWithNoMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04B21BC9824000AC98FD /* ValueWithObjectMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04981BC9820A00AC98FD /* ValueWithObjectMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04B31BC9824000AC98FD /* ValueWithValueMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04991BC9820A00AC98FD /* ValueWithValueMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04B41BC9824000AC98FD /* YapDatabaseExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B049A1BC9820A00AC98FD /* YapDatabaseExtensionsTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04B61BC9824100AC98FD /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04901BC9820A00AC98FD /* Models.swift */; settings = {ASSET_TAGS = (); }; };
-		653B04B71BC9824100AC98FD /* ObjectWithNoMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04911BC9820A00AC98FD /* ObjectWithNoMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04B81BC9824100AC98FD /* ObjectWithObjectMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04921BC9820A00AC98FD /* ObjectWithObjectMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04B91BC9824100AC98FD /* ObjectWithValueMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04931BC9820A00AC98FD /* ObjectWithValueMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04BA1BC9824100AC98FD /* ReadWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04941BC9820A00AC98FD /* ReadWriteTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04BB1BC9824100AC98FD /* RemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04951BC9820A00AC98FD /* RemovalTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04BC1BC9824100AC98FD /* Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04961BC9820A00AC98FD /* Support.swift */; settings = {ASSET_TAGS = (); }; };
-		653B04BD1BC9824100AC98FD /* ValueWithNoMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04971BC9820A00AC98FD /* ValueWithNoMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04BE1BC9824100AC98FD /* ValueWithObjectMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04981BC9820A00AC98FD /* ValueWithObjectMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04BF1BC9824100AC98FD /* ValueWithValueMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04991BC9820A00AC98FD /* ValueWithValueMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04C01BC9824100AC98FD /* YapDatabaseExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B049A1BC9820A00AC98FD /* YapDatabaseExtensionsTests.swift */; settings = {ASSET_TAGS = (); }; };
@@ -49,14 +45,10 @@
 		65C557901BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C557911BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557801BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C557921BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557801BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
-		65C557931BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557821BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
-		65C557941BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557821BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C557951BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557831BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C557961BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557831BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C557971BCB26010065C96A /* Persistable_ObjectWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557841BCB26010065C96A /* Persistable_ObjectWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C557981BCB26010065C96A /* Persistable_ObjectWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557841BCB26010065C96A /* Persistable_ObjectWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
-		65C557991BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557851BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
-		65C5579A1BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557851BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5579B1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557861BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5579C1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557861BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5579D1BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C557871BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
@@ -646,7 +638,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65C557931BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift in Sources */,
 				653B04861BC981D100AC98FD /* YapDB.swift in Sources */,
 				65C557A61BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579B1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
@@ -654,7 +645,6 @@
 				65C557A31BCB26010065C96A /* Write.swift in Sources */,
 				65C557911BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
 				65C5578F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
-				65C557991BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift in Sources */,
 				653B04851BC981D100AC98FD /* YapDatabaseExtensions.swift in Sources */,
 				65C557951BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift in Sources */,
 				65C557A11BCB26010065C96A /* Remove.swift in Sources */,
@@ -671,12 +661,10 @@
 			files = (
 				653B04AF1BC9824000AC98FD /* RemovalTests.swift in Sources */,
 				653B04AC1BC9824000AC98FD /* ObjectWithObjectMetadataTests.swift in Sources */,
-				653B04AB1BC9824000AC98FD /* ObjectWithNoMetadataTests.swift in Sources */,
 				653B04AD1BC9824000AC98FD /* ObjectWithValueMetadataTests.swift in Sources */,
 				653B04B21BC9824000AC98FD /* ValueWithObjectMetadataTests.swift in Sources */,
 				653B04B41BC9824000AC98FD /* YapDatabaseExtensionsTests.swift in Sources */,
 				653B04B01BC9824000AC98FD /* Support.swift in Sources */,
-				653B04B11BC9824000AC98FD /* ValueWithNoMetadataTests.swift in Sources */,
 				653B04AA1BC9824000AC98FD /* Models.swift in Sources */,
 				653B04B31BC9824000AC98FD /* ValueWithValueMetadataTests.swift in Sources */,
 				653B04AE1BC9824000AC98FD /* ReadWriteTests.swift in Sources */,
@@ -687,7 +675,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65C557941BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift in Sources */,
 				653B048B1BC981D700AC98FD /* YapDB.swift in Sources */,
 				65C557A71BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579C1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
@@ -695,7 +682,6 @@
 				65C557A41BCB26010065C96A /* Write.swift in Sources */,
 				65C557921BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
 				65C557901BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
-				65C5579A1BCB26010065C96A /* Persistable_ValueWithNoMetadata.swift in Sources */,
 				653B048A1BC981D700AC98FD /* YapDatabaseExtensions.swift in Sources */,
 				65C557961BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift in Sources */,
 				65C557A21BCB26010065C96A /* Remove.swift in Sources */,
@@ -712,12 +698,10 @@
 			files = (
 				653B04BB1BC9824100AC98FD /* RemovalTests.swift in Sources */,
 				653B04B81BC9824100AC98FD /* ObjectWithObjectMetadataTests.swift in Sources */,
-				653B04B71BC9824100AC98FD /* ObjectWithNoMetadataTests.swift in Sources */,
 				653B04B91BC9824100AC98FD /* ObjectWithValueMetadataTests.swift in Sources */,
 				653B04BE1BC9824100AC98FD /* ValueWithObjectMetadataTests.swift in Sources */,
 				653B04C01BC9824100AC98FD /* YapDatabaseExtensionsTests.swift in Sources */,
 				653B04BC1BC9824100AC98FD /* Support.swift in Sources */,
-				653B04BD1BC9824100AC98FD /* ValueWithNoMetadataTests.swift in Sources */,
 				653B04B61BC9824100AC98FD /* Models.swift in Sources */,
 				653B04BF1BC9824100AC98FD /* ValueWithValueMetadataTests.swift in Sources */,
 				653B04BA1BC9824100AC98FD /* ReadWriteTests.swift in Sources */,

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithNoMetadata.swift
@@ -1,0 +1,224 @@
+//
+//  Functional_ObjectWithNoMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 13/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+import YapDatabase
+
+// MARK: - Reading
+
+extension ReadTransactionType {
+
+    /**
+    Reads the item at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `ItemType`
+    */
+    public func readAtIndex<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(index: YapDB.Index) -> ObjectWithNoMetadata? {
+            return readAtIndex(index) as? ObjectWithNoMetadata
+    }
+
+    /**
+    Reads the items at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `ItemType`
+    */
+    public func readAtIndexes<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(indexes: [YapDB.Index]) -> [ObjectWithNoMetadata] {
+            return indexes.flatMap(readAtIndex)
+    }
+
+    /**
+    Reads the item at the key.
+
+    - parameter key: a String
+    - returns: an optional `ItemType`
+    */
+    public func readByKey<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(key: String) -> ObjectWithNoMetadata? {
+            return readAtIndex(ObjectWithNoMetadata.indexWithKey(key))
+    }
+
+    /**
+    Reads the items by the keys.
+
+    - parameter keys: an array of String
+    - returns: an array of `ItemType`
+    */
+    public func readByKeys<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(keys: [String]) -> [ObjectWithNoMetadata] {
+            return readAtIndexes(ObjectWithNoMetadata.indexesWithKeys(keys))
+    }
+}
+
+extension ConnectionType {
+
+    /**
+    Reads the item at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `ItemType`
+    */
+    public func readAtIndex<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(index: YapDB.Index) -> ObjectWithNoMetadata? {
+            return read { $0.readAtIndex(index) }
+    }
+
+    /**
+    Reads the items at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `ItemType`
+    */
+    public func readAtIndexes<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(indexes: [YapDB.Index]) -> [ObjectWithNoMetadata] {
+            return read { $0.readAtIndexes(indexes) }
+    }
+
+    /**
+    Reads the item at the key.
+
+    - parameter key: a String
+    - returns: an optional `ItemType`
+    */
+    public func readByKey<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(key: String) -> ObjectWithNoMetadata? {
+            return readAtIndex(ObjectWithNoMetadata.indexWithKey(key))
+    }
+
+    /**
+    Reads the items by the keys.
+
+    - parameter keys: an array of String
+    - returns: an array of `ItemType`
+    */
+    public func readByKeys<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(keys: [String]) -> [ObjectWithNoMetadata] {
+            return readAtIndexes(ObjectWithNoMetadata.indexesWithKeys(keys))
+    }
+}
+
+// MARK: - Writable
+
+extension WriteTransactionType {
+
+    /**
+    Write the item to the database using the transaction.
+
+    - parameter item: the item to store.
+    */
+    public func write<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(item: ObjectWithNoMetadata) {
+            writeAtIndex(item.index, object: item, metadata: .None)
+    }
+
+    /**
+    Write the items to the database using the transaction.
+
+    - parameter items: an array of items to store.
+    */
+    public func write<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(items: [ObjectWithNoMetadata]) {
+            items.forEach(write)
+    }
+}
+
+extension ConnectionType {
+
+    /**
+    Write the item to the database synchronously using the connection in a new transaction.
+
+    - parameter item: the item to store.
+    */
+    public func write<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(item: ObjectWithNoMetadata) {
+            write { $0.write(item) }
+    }
+
+    /**
+    Write the items to the database synchronously using the connection in a new transaction.
+
+    - parameter items: an array of items to store.
+    */
+    public func write<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(items: [ObjectWithNoMetadata]) {
+            write { $0.write(items) }
+    }
+
+    /**
+    Write the item to the database asynchronously using the connection in a new transaction.
+
+    - parameter item: the item to store.
+    - parameter queue: the dispatch_queue_t to run the completion block on.
+    - parameter completion: a dispatch_block_t for completion.
+    */
+    public func asyncWrite<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(item: ObjectWithNoMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t) {
+            asyncWrite({ $0.write(item) }, queue: queue, completion: { _ in completion() })
+    }
+
+    /**
+    Write the items to the database asynchronously using the connection in a new transaction.
+
+    - parameter items: an array of items to store.
+    - parameter queue: the dispatch_queue_t to run the completion block on.
+    - parameter completion: a dispatch_block_t for completion.
+    */
+    public func asyncWrite<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>(items: [ObjectWithNoMetadata], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t) {
+            asyncWrite({ $0.write(items) }, queue: queue, completion: { _ in completion() })
+    }
+}
+
+
+

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
@@ -22,7 +22,7 @@ extension ReadTransactionType {
     */
     public func readAtIndex<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(index: YapDB.Index) -> ObjectWithObjectMetadata? {
             if var item = readAtIndex(index) as? ObjectWithObjectMetadata {
@@ -40,7 +40,7 @@ extension ReadTransactionType {
     */
     public func readAtIndexes<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(indexes: [YapDB.Index]) -> [ObjectWithObjectMetadata] {
             return indexes.flatMap(readAtIndex)
@@ -54,7 +54,7 @@ extension ReadTransactionType {
     */
     public func readByKey<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(key: String) -> ObjectWithObjectMetadata? {
             return readAtIndex(ObjectWithObjectMetadata.indexWithKey(key))
@@ -68,7 +68,7 @@ extension ReadTransactionType {
     */
     public func readByKeys<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(keys: [String]) -> [ObjectWithObjectMetadata] {
             return readAtIndexes(ObjectWithObjectMetadata.indexesWithKeys(keys))
@@ -85,7 +85,7 @@ extension ConnectionType {
     */
     public func readAtIndex<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(index: YapDB.Index) -> ObjectWithObjectMetadata? {
             return read { $0.readAtIndex(index) }
@@ -99,7 +99,7 @@ extension ConnectionType {
     */
     public func readAtIndexes<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(indexes: [YapDB.Index]) -> [ObjectWithObjectMetadata] {
             return read { $0.readAtIndexes(indexes) }
@@ -113,7 +113,7 @@ extension ConnectionType {
     */
     public func readByKey<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(key: String) -> ObjectWithObjectMetadata? {
             return readAtIndex(ObjectWithObjectMetadata.indexWithKey(key))
@@ -127,7 +127,7 @@ extension ConnectionType {
     */
     public func readByKeys<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(keys: [String]) -> [ObjectWithObjectMetadata] {
             return readAtIndexes(ObjectWithObjectMetadata.indexesWithKeys(keys))
@@ -145,7 +145,7 @@ extension WriteTransactionType {
     */
     public func write<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(item: ObjectWithObjectMetadata) {
             writeAtIndex(item.index, object: item, metadata: item.metadata)
@@ -158,7 +158,7 @@ extension WriteTransactionType {
     */
     public func write<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(items: [ObjectWithObjectMetadata]) {
             items.forEach(write)
@@ -174,7 +174,7 @@ extension ConnectionType {
     */
     public func write<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(item: ObjectWithObjectMetadata) {
             write { $0.write(item) }
@@ -187,7 +187,7 @@ extension ConnectionType {
     */
     public func write<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(items: [ObjectWithObjectMetadata]) {
             write { $0.write(items) }
@@ -202,7 +202,7 @@ extension ConnectionType {
     */
     public func asyncWrite<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(item: ObjectWithObjectMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t) {
             asyncWrite({ $0.write(item) }, queue: queue, completion: { _ in completion() })
@@ -217,7 +217,7 @@ extension ConnectionType {
     */
     public func asyncWrite<
         ObjectWithObjectMetadata where
-        ObjectWithObjectMetadata: MetadataPersistable,
+        ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(items: [ObjectWithObjectMetadata], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t) {
             asyncWrite({ $0.write(items) }, queue: queue, completion: { _ in completion() })

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithValueMetadata.swift
@@ -22,7 +22,7 @@ extension ReadTransactionType {
     */
     public func readAtIndex<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -42,7 +42,7 @@ extension ReadTransactionType {
     */
     public func readAtIndexes<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -58,7 +58,7 @@ extension ReadTransactionType {
     */
     public func readByKey<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -74,7 +74,7 @@ extension ReadTransactionType {
     */
     public func readByKeys<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -93,7 +93,7 @@ extension ConnectionType {
     */
     public func readAtIndex<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -109,7 +109,7 @@ extension ConnectionType {
     */
     public func readAtIndexes<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -125,7 +125,7 @@ extension ConnectionType {
     */
     public func readByKey<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -141,7 +141,7 @@ extension ConnectionType {
     */
     public func readByKeys<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -161,7 +161,7 @@ extension WriteTransactionType {
     */
     public func write<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -176,7 +176,7 @@ extension WriteTransactionType {
     */
     public func write<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -194,7 +194,7 @@ extension ConnectionType {
     */
     public func write<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -209,7 +209,7 @@ extension ConnectionType {
     */
     public func write<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -226,7 +226,7 @@ extension ConnectionType {
     */
     public func asyncWrite<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
@@ -243,7 +243,7 @@ extension ConnectionType {
     */
     public func asyncWrite<
         ObjectWithValueMetadata where
-        ObjectWithValueMetadata: MetadataPersistable,
+        ObjectWithValueMetadata: Persistable,
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthObjectMetadata.swift
@@ -22,7 +22,7 @@ extension ReadTransactionType {
     */
     public func readAtIndex<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -42,7 +42,7 @@ extension ReadTransactionType {
     */
     public func readAtIndexes<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -58,7 +58,7 @@ extension ReadTransactionType {
     */
     public func readByKey<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -74,7 +74,7 @@ extension ReadTransactionType {
     */
     public func readByKeys<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -93,7 +93,7 @@ extension ConnectionType {
     */
     public func readAtIndex<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -109,7 +109,7 @@ extension ConnectionType {
     */
     public func readAtIndexes<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -125,7 +125,7 @@ extension ConnectionType {
     */
     public func readByKey<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -141,7 +141,7 @@ extension ConnectionType {
     */
     public func readByKeys<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -161,7 +161,7 @@ extension WriteTransactionType {
     */
     public func write<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -176,7 +176,7 @@ extension WriteTransactionType {
     */
     public func write<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -194,7 +194,7 @@ extension ConnectionType {
     */
     public func write<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -209,7 +209,7 @@ extension ConnectionType {
     */
     public func write<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -226,7 +226,7 @@ extension ConnectionType {
     */
     public func asyncWrite<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
@@ -243,7 +243,7 @@ extension ConnectionType {
     */
     public func asyncWrite<
         ValueWithObjectMetadata where
-        ValueWithObjectMetadata: MetadataPersistable,
+        ValueWithObjectMetadata: Persistable,
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthValueMetadata.swift
@@ -22,7 +22,7 @@ extension ReadTransactionType {
     */
     public func readAtIndex<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -44,7 +44,7 @@ extension ReadTransactionType {
     */
     public func readAtIndexes<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -62,7 +62,7 @@ extension ReadTransactionType {
     */
     public func readByKey<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -80,7 +80,7 @@ extension ReadTransactionType {
     */
     public func readByKeys<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -101,7 +101,7 @@ extension ConnectionType {
     */
     public func readAtIndex<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -119,7 +119,7 @@ extension ConnectionType {
     */
     public func readAtIndexes<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -137,7 +137,7 @@ extension ConnectionType {
     */
     public func readByKey<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -155,7 +155,7 @@ extension ConnectionType {
     */
     public func readByKeys<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -177,7 +177,7 @@ extension WriteTransactionType {
     */
     public func write<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -194,7 +194,7 @@ extension WriteTransactionType {
     */
     public func write<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -214,7 +214,7 @@ extension ConnectionType {
     */
     public func write<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -231,7 +231,7 @@ extension ConnectionType {
     */
     public func write<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -250,7 +250,7 @@ extension ConnectionType {
     */
     public func asyncWrite<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
@@ -269,7 +269,7 @@ extension ConnectionType {
     */
     public func asyncWrite<
         ValueWithValueMetadata where
-        ValueWithValueMetadata: MetadataPersistable,
+        ValueWithValueMetadata: Persistable,
         ValueWithValueMetadata: ValueCoding,
         ValueWithValueMetadata.Coder: NSCoding,
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWithNoMetadata.swift
@@ -1,0 +1,250 @@
+//
+//  Functional_ValueWithNoMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 13/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+import YapDatabase
+
+// MARK: - Reading
+
+extension ReadTransactionType {
+
+    /**
+    Reads the item at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `ItemType`
+    */
+    public func readAtIndex<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(index: YapDB.Index) -> ValueWithNoMetadata? {
+            return ValueWithNoMetadata.decode(readAtIndex(index))
+    }
+
+    /**
+    Reads the items at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `ItemType`
+    */
+    public func readAtIndexes<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(indexes: [YapDB.Index]) -> [ValueWithNoMetadata] {
+            return indexes.flatMap(readAtIndex)
+    }
+
+    /**
+    Reads the item at the key.
+
+    - parameter key: a String
+    - returns: an optional `ItemType`
+    */
+    public func readByKey<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(key: String) -> ValueWithNoMetadata? {
+            return readAtIndex(ValueWithNoMetadata.indexWithKey(key))
+    }
+
+    /**
+    Reads the items by the keys.
+
+    - parameter keys: an array of String
+    - returns: an array of `ItemType`
+    */
+    public func readByKeys<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(keys: [String]) -> [ValueWithNoMetadata] {
+            return readAtIndexes(ValueWithNoMetadata.indexesWithKeys(keys))
+    }
+}
+
+extension ConnectionType {
+
+    /**
+    Reads the item at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `ItemType`
+    */
+    public func readAtIndex<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(index: YapDB.Index) -> ValueWithNoMetadata? {
+            return read { $0.readAtIndex(index) }
+    }
+
+    /**
+    Reads the items at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `ItemType`
+    */
+    public func readAtIndexes<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(indexes: [YapDB.Index]) -> [ValueWithNoMetadata] {
+            return read { $0.readAtIndexes(indexes) }
+    }
+
+    /**
+    Reads the item at the key.
+
+    - parameter key: a String
+    - returns: an optional `ItemType`
+    */
+    public func readByKey<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(key: String) -> ValueWithNoMetadata? {
+            return readAtIndex(ValueWithNoMetadata.indexWithKey(key))
+    }
+
+    /**
+    Reads the items by the keys.
+
+    - parameter keys: an array of String
+    - returns: an array of `ItemType`
+    */
+    public func readByKeys<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(keys: [String]) -> [ValueWithNoMetadata] {
+            return readAtIndexes(ValueWithNoMetadata.indexesWithKeys(keys))
+    }
+}
+
+// MARK: - Writing
+
+extension WriteTransactionType {
+
+    /**
+    Write the item to the database using the transaction.
+
+    - parameter item: the item to store.
+    */
+    public func write<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(item: ValueWithNoMetadata) {
+            writeAtIndex(item.index, object: item.encoded, metadata: .None)
+    }
+
+    /**
+    Write the items to the database using the transaction.
+
+    - parameter items: an array of items to store.
+    */
+    public func write<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(items: [ValueWithNoMetadata]) {
+            items.forEach(write)
+    }
+}
+
+extension ConnectionType {
+
+    /**
+    Write the item to the database synchronously using the connection in a new transaction.
+
+    - parameter item: the item to store.
+    */
+    public func write<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(item: ValueWithNoMetadata) {
+            write { $0.write(item) }
+    }
+
+    /**
+    Write the items to the database synchronously using the connection in a new transaction.
+
+    - parameter items: an array of items to store.
+    */
+    public func write<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(items: [ValueWithNoMetadata]) {
+            write { $0.write(items) }
+    }
+
+    /**
+    Write the item to the database asynchronously using the connection in a new transaction.
+
+    - parameter item: the item to store.
+    - parameter queue: the dispatch_queue_t to run the completion block on.
+    - parameter completion: a dispatch_block_t for completion.
+    */
+    public func asyncWrite<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(item: ValueWithNoMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t) {
+            asyncWrite({ $0.write(item) }, queue: queue, completion: { _ in completion() })
+    }
+
+    /**
+    Write the items to the database asynchronously using the connection in a new transaction.
+
+    - parameter items: an array of items to store.
+    - parameter queue: the dispatch_queue_t to run the completion block on.
+    - parameter completion: a dispatch_block_t for completion.
+    */
+    public func asyncWrite<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>(items: [ValueWithNoMetadata], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t) {
+            asyncWrite({ $0.write(items) }, queue: queue, completion: { _ in completion() })
+    }
+}
+

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithNoMetadata.swift
@@ -14,7 +14,8 @@ import YapDatabase
 
 extension Readable where
     ItemType: NSCoding,
-    ItemType: Persistable {
+    ItemType: Persistable,
+    ItemType.MetadataType == Void {
 
     func inTransaction(transaction: Database.Connection.ReadTransaction, atIndex index: YapDB.Index) -> ItemType? {
         return transaction.readAtIndex(index) as? ItemType
@@ -129,7 +130,8 @@ extension Readable where
 extension Writable
     where
     ItemType: NSCoding,
-    ItemType: Persistable {
+    ItemType: Persistable,
+    ItemType.MetadataType == Void {
 
     /**
     Write the items using an existing transaction.

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithObjectMetadata.swift
@@ -14,7 +14,7 @@ import YapDatabase
 
 extension Readable where
     ItemType: NSCoding,
-    ItemType: MetadataPersistable,
+    ItemType: Persistable,
     ItemType.MetadataType: NSCoding {
 
     func inTransaction(transaction: Database.Connection.ReadTransaction, atIndex index: YapDB.Index) -> ItemType? {
@@ -129,7 +129,7 @@ extension Readable where
 extension Writable
     where
     ItemType: NSCoding,
-    ItemType: MetadataPersistable,
+    ItemType: Persistable,
     ItemType.MetadataType: NSCoding {
 
     /**

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithValueMetadata.swift
@@ -14,7 +14,7 @@ import YapDatabase
 
 extension Readable where
     ItemType: NSCoding,
-    ItemType: MetadataPersistable,
+    ItemType: Persistable,
     ItemType.MetadataType: ValueCoding,
     ItemType.MetadataType.Coder: NSCoding,
     ItemType.MetadataType.Coder.ValueType == ItemType.MetadataType {
@@ -131,7 +131,7 @@ extension Readable where
 
 extension Writable where
     ItemType: NSCoding,
-    ItemType: MetadataPersistable,
+    ItemType: Persistable,
     ItemType.MetadataType: ValueCoding,
     ItemType.MetadataType.Coder: NSCoding,
     ItemType.MetadataType.Coder.ValueType == ItemType.MetadataType {

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithNoMetadata.swift
@@ -15,6 +15,7 @@ import YapDatabase
 extension Readable where
     ItemType: ValueCoding,
     ItemType: Persistable,
+    ItemType.MetadataType == Void,
     ItemType.Coder: NSCoding,
     ItemType.Coder.ValueType == ItemType {
 
@@ -131,6 +132,7 @@ extension Readable where
 extension Writable where
     ItemType: ValueCoding,
     ItemType: Persistable,
+    ItemType.MetadataType == Void,    
     ItemType.Coder: NSCoding,
     ItemType.Coder.ValueType == ItemType {
 

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithObjectMetadata.swift
@@ -14,7 +14,7 @@ import YapDatabase
 
 extension Readable where
     ItemType: ValueCoding,
-    ItemType: MetadataPersistable,
+    ItemType: Persistable,
     ItemType.Coder: NSCoding,
     ItemType.Coder.ValueType == ItemType,
     ItemType.MetadataType: NSCoding {
@@ -130,7 +130,7 @@ extension Readable where
 
 extension Writable where
     ItemType: ValueCoding,
-    ItemType: MetadataPersistable,
+    ItemType: Persistable,
     ItemType.Coder: NSCoding,
     ItemType.Coder.ValueType == ItemType,
     ItemType.MetadataType: NSCoding {

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithValueMetadata.swift
@@ -14,7 +14,7 @@ import YapDatabase
 
 extension Readable where
     ItemType: ValueCoding,
-    ItemType: MetadataPersistable,
+    ItemType: Persistable,
     ItemType.Coder: NSCoding,
     ItemType.Coder.ValueType == ItemType,
     ItemType.MetadataType: ValueCoding,
@@ -132,7 +132,7 @@ extension Readable where
 
 extension Writable where
     ItemType: ValueCoding,
-    ItemType: MetadataPersistable,
+    ItemType: Persistable,
     ItemType.Coder: NSCoding,
     ItemType.Coder.ValueType == ItemType,
     ItemType.MetadataType: ValueCoding,

--- a/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
+++ b/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
@@ -183,8 +183,14 @@ are stored in the same YapDatabase collection.
 */
 public protocol Persistable: Identifiable {
 
+    /// The nested type of the metadata. Defaults to Void.
+    typealias MetadataType
+
     /// The YapDatabase collection name the type is stored in.
     static var collection: String { get }
+
+    /// A metadata which is set when reading, and get when writing.
+    var metadata: MetadataType? { get set }
 }
 
 extension Persistable {
@@ -215,6 +221,15 @@ extension Persistable {
     }
 
     /**
+    Default metadata property. Override this to re-define your
+    own MetadataType.
+    */
+    public var metadata: Void? {
+        get { return .None }
+        set { }
+    }
+
+    /**
     Convenience computed property to get the key
     for a persistable, which is just the identifier's description.
 
@@ -241,12 +256,12 @@ In order to read/write your metadata types from/to YapDatabase they must
 implement either NSCoding (i.e. be object based) or ValueCoding (i.e. be
 value based).
 */
-public protocol MetadataPersistable: Persistable {
-    typealias MetadataType
-
-    /// A metadata which is set when reading, and get when writing.
-    var metadata: MetadataType? { get set }
-}
+//public protocol MetadataPersistable: Persistable {
+//    typealias MetadataType
+//
+//    /// A metadata which is set when reading, and get when writing.
+//    var metadata: MetadataType? { get set }
+//}
 
 /// A facade interface for a read transaction.
 public protocol ReadTransactionType {
@@ -599,10 +614,10 @@ public func indexForPersistable<P: Persistable>(persistable: P) -> YapDB.Index {
 // MARK: - Deprecations
 
 @available(*, unavailable, renamed="MetadataPersistable")
-public typealias ObjectMetadataPersistable = MetadataPersistable
+public typealias ObjectMetadataPersistable = Persistable
 
 @available(*, unavailable, renamed="MetadataPersistable")
-public typealias ValueMetadataPersistable = MetadataPersistable
+public typealias ValueMetadataPersistable = Persistable
 
 @available(*, unavailable, renamed="ValueCoding")
 public typealias Saveable = ValueCoding

--- a/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
+++ b/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
@@ -249,20 +249,6 @@ extension Persistable {
     }
 }
 
-/**
-A generic protocol for Persistable which support YapDatabase metadata.
-
-In order to read/write your metadata types from/to YapDatabase they must
-implement either NSCoding (i.e. be object based) or ValueCoding (i.e. be
-value based).
-*/
-//public protocol MetadataPersistable: Persistable {
-//    typealias MetadataType
-//
-//    /// A metadata which is set when reading, and get when writing.
-//    var metadata: MetadataType? { get set }
-//}
-
 /// A facade interface for a read transaction.
 public protocol ReadTransactionType {
 

--- a/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
+++ b/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
@@ -221,7 +221,7 @@ extension Persistable {
     }
 
     /**
-    Default metadata property. Override this to re-define your
+    Default metadata property. Implement this to re-define your
     own MetadataType.
     */
     public var metadata: Void? {

--- a/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
+++ b/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
@@ -599,10 +599,13 @@ public func indexForPersistable<P: Persistable>(persistable: P) -> YapDB.Index {
 
 // MARK: - Deprecations
 
-@available(*, unavailable, renamed="MetadataPersistable")
+@available(*, unavailable, renamed="Persistable")
+public typealias MetadataPersistable = Persistable
+
+@available(*, unavailable, renamed="Persistable")
 public typealias ObjectMetadataPersistable = Persistable
 
-@available(*, unavailable, renamed="MetadataPersistable")
+@available(*, unavailable, renamed="Persistable")
 public typealias ValueMetadataPersistable = Persistable
 
 @available(*, unavailable, renamed="ValueCoding")


### PR DESCRIPTION
It would be possible to provide a default empty metadata in an extension which consumers could override. This would remove some of the ambiguity in adoption, plus reduce the implementation / surface area.
