### PR TITLE
Metadata should be read/write capable independently

### DIFF
--- a/Tests/Shared/ObjectWithObjectMetadataTests.swift
+++ b/Tests/Shared/ObjectWithObjectMetadataTests.swift
@@ -502,6 +502,18 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         XCTAssertNil(employee)
     }
 
+    func test__transaction__read_metadata_at_index_with_data() {
+        configureForReadingSingle()
+        let result: Employee.MetadataType? = readTransaction.readMetadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!, item.metadata)
+    }
+
+    func test__transaction__read_metadata_at_index_without_data() {
+        let result: Employee.MetadataType? = readTransaction.readMetadataAtIndex(index)
+        XCTAssertNil(result)
+    }
+
     func test__transaction__read_at_indexes_with_data() {
         configureForReadingMultiple()
         let employees: [Employee] = readTransaction.readAtIndexes(indexes)
@@ -512,6 +524,18 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         let employees: [Employee] = readTransaction.readAtIndexes(indexes)
         XCTAssertNotNil(employees)
         XCTAssertTrue(employees.isEmpty)
+    }
+
+    func test__transaction__read_metadata_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result: [Employee.MetadataType] = readTransaction.readMetadataAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__transaction__read_metadata_at_indexes_without_data() {
+        let result: [Employee.MetadataType] = readTransaction.readMetadataAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__transaction__read_by_key_with_data() {
@@ -554,6 +578,18 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         XCTAssertNil(employee)
     }
 
+    func test__connection__read_metadata_at_index_with_data() {
+        configureForReadingSingle()
+        let result: Employee.MetadataType? = connection.readMetadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!, item.metadata)
+    }
+
+    func test__connection__read_metadata_at_index_without_data() {
+        let result: Employee.MetadataType? = connection.readMetadataAtIndex(index)
+        XCTAssertNil(result)
+    }
+
     func test__connection__read_at_indexes_with_data() {
         configureForReadingMultiple()
         let employees: [Employee] = connection.readAtIndexes(indexes)
@@ -564,6 +600,18 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         let employees: [Employee] = connection.readAtIndexes(indexes)
         XCTAssertNotNil(employees)
         XCTAssertTrue(employees.isEmpty)
+    }
+
+    func test__connection__read_metadata_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result: [Employee.MetadataType] = connection.readMetadataAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__connection__read_metadata_at_indexes_without_data() {
+        let result: [Employee.MetadataType] = connection.readMetadataAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__connection__read_by_key_with_data() {

--- a/Tests/Shared/ObjectWithObjectMetadataTests.swift
+++ b/Tests/Shared/ObjectWithObjectMetadataTests.swift
@@ -301,6 +301,24 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func test__reader_with_transaction__metadata_at_index_with_item() {
+        configureForReadingSingle()
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result, item.metadata)
+    }
+
+    func test__reader_with_transaction__metadata_at_index_with_no_item() {
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertNil(result)
+    }
+
     func test__reader_with_transaction__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
@@ -314,6 +332,23 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(result, [])
+    }
+
+    func test__reader_with_transaction__metadata_at_indexes_with_items() {
+        configureForReadingMultiple()
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.count, items.map { $0.metadata }.count)
+    }
+
+    func test__reader_with_transaction__metadata_at_indexes_with_no_items() {
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result, [])
     }
 
@@ -400,6 +435,26 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func test__reader_with_connection__metadata_at_index_with_item() {
+        configureForReadingSingle()
+        reader = Read(connection)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result, item.metadata)
+    }
+
+    func test__reader_with_connection__metadata_at_index_with_no_item() {
+        reader = Read(connection)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertNil(result)
+    }
+
     func test__reader_with_connection__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
@@ -415,6 +470,25 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(result, [])
+    }
+
+    func test__reader_with_connection__metadata_at_indexes_with_items() {
+        configureForReadingMultiple()
+        reader = Read(connection)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.count, items.map { $0.metadata }.count)
+    }
+
+    func test__reader_with_connection__metadata_at_indexes_with_no_items() {
+        reader = Read(connection)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result, [])
     }
 

--- a/Tests/Shared/ObjectWithValueMetadataTests.swift
+++ b/Tests/Shared/ObjectWithValueMetadataTests.swift
@@ -84,10 +84,12 @@ class ObjectWithValueMetadataTests: XCTestCase {
 
     func configureForReadingSingle() {
         readTransaction.object = item
+        readTransaction.metadata = item.metadata?.encoded
     }
 
     func configureForReadingMultiple() {
         readTransaction.objects = items
+        readTransaction.metadatas = items.map { $0.metadata?.encoded }
         readTransaction.keys = keys
     }
 
@@ -470,6 +472,18 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNil(manager)
     }
 
+    func test__transaction__read_metadata_at_index_with_data() {
+        configureForReadingSingle()
+        let result: Manager.MetadataType? = readTransaction.readMetadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!, item.metadata)
+    }
+
+    func test__transaction__read_metadata_at_index_without_data() {
+        let result: Manager.MetadataType? = readTransaction.readMetadataAtIndex(index)
+        XCTAssertNil(result)
+    }
+
     func test__transaction__read_at_indexes_with_data() {
         configureForReadingMultiple()
         let managers: [Manager] = readTransaction.readAtIndexes(indexes)
@@ -480,6 +494,18 @@ class ObjectWithValueMetadataTests: XCTestCase {
         let managers: [Manager] = readTransaction.readAtIndexes(indexes)
         XCTAssertNotNil(managers)
         XCTAssertTrue(managers.isEmpty)
+    }
+
+    func test__transaction__read_metadata_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result: [Manager.MetadataType] = readTransaction.readMetadataAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__transaction__read_metadata_at_indexes_without_data() {
+        let result: [Manager.MetadataType] = readTransaction.readMetadataAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__transaction__read_by_key_with_data() {
@@ -520,6 +546,18 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNil(manager)
     }
 
+    func test__connection__read_metadata_at_index_with_data() {
+        configureForReadingSingle()
+        let result: Manager.MetadataType? = connection.readMetadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!, item.metadata)
+    }
+
+    func test__connection__read_metadata_at_index_without_data() {
+        let result: Manager.MetadataType? = connection.readMetadataAtIndex(index)
+        XCTAssertNil(result)
+    }
+
     func test__connection__read_at_indexes_with_data() {
         configureForReadingMultiple()
         let managers: [Manager] = connection.readAtIndexes(indexes)
@@ -530,6 +568,18 @@ class ObjectWithValueMetadataTests: XCTestCase {
         let managers: [Manager] = connection.readAtIndexes(indexes)
         XCTAssertNotNil(managers)
         XCTAssertTrue(managers.isEmpty)
+    }
+
+    func test__connection__read_metadata_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result: [Manager.MetadataType] = connection.readMetadataAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__connection__read_metadata_at_indexes_without_data() {
+        let result: [Manager.MetadataType] = connection.readMetadataAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__connection__read_by_key_with_data() {

--- a/Tests/Shared/ObjectWithValueMetadataTests.swift
+++ b/Tests/Shared/ObjectWithValueMetadataTests.swift
@@ -176,6 +176,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__in_transaction_at_index_2() {
@@ -186,6 +188,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__at_index_in_transaction() {
@@ -196,6 +200,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
@@ -203,6 +209,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -220,6 +227,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__in_transaction_by_key_2() {
@@ -230,6 +239,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__by_key_in_transaction() {
@@ -240,6 +251,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
@@ -247,6 +260,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -255,6 +269,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.byKeysInTransaction()(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(readTransaction.didKeysInCollection!, Manager.collection)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
@@ -275,6 +290,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
@@ -284,11 +301,30 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func test__reader_with_transaction__metadata_at_index_with_item() {
+        configureForReadingSingle()
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result, item.metadata)
+    }
+
+    func test__reader_with_transaction__metadata_at_index_with_no_item() {
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertNil(result)
+    }
+
     func test__reader_with_transaction__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
         let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -299,6 +335,23 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertEqual(result, [])
     }
 
+    func test__reader_with_transaction__metadata_at_indexes_with_items() {
+        configureForReadingMultiple()
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.count, items.map { $0.metadata }.count)
+    }
+
+    func test__reader_with_transaction__metadata_at_indexes_with_no_items() {
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result, [])
+    }
+
     func test__reader_with_transaction__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
@@ -306,6 +359,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
@@ -320,6 +375,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -352,6 +408,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let (result, missing) = reader.filterExisting(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes.first!, indexes.first!)
         XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
@@ -366,6 +423,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
@@ -376,12 +435,33 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func test__reader_with_connection__metadata_at_index_with_item() {
+        configureForReadingSingle()
+        reader = Read(connection)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result, item.metadata)
+    }
+
+    func test__reader_with_connection__metadata_at_index_with_no_item() {
+        reader = Read(connection)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertNil(result)
+    }
+
     func test__reader_with_connection__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
         let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -393,6 +473,25 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertEqual(result, [])
     }
 
+    func test__reader_with_connection__metadata_at_indexes_with_items() {
+        configureForReadingMultiple()
+        reader = Read(connection)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.count, items.map { $0.metadata }.count)
+    }
+
+    func test__reader_with_connection__metadata_at_indexes_with_no_items() {
+        reader = Read(connection)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result, [])
+    }
+
     func test__reader_with_connection__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
@@ -401,6 +500,8 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {
@@ -417,6 +518,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
         let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -435,6 +537,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Manager.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -453,10 +556,10 @@ class ObjectWithValueMetadataTests: XCTestCase {
         let (result, missing) = reader.filterExisting(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes.first!, indexes.first!)
         XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
-
 
     // Functional API - ReadTransactionType - Reading
 

--- a/Tests/Shared/ValueWithObjectMetadataTests.swift
+++ b/Tests/Shared/ValueWithObjectMetadataTests.swift
@@ -196,6 +196,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__in_transaction_at_index_2() {
@@ -206,6 +208,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__at_index_in_transaction() {
@@ -216,6 +220,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
@@ -223,6 +229,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -240,6 +247,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__in_transaction_by_key_2() {
@@ -250,6 +259,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__by_key_in_transaction() {
@@ -260,6 +271,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
@@ -267,6 +280,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -275,6 +289,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.byKeysInTransaction()(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(readTransaction.didKeysInCollection!, Inventory.collection)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
@@ -295,6 +310,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
@@ -304,11 +321,30 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func test__reader_with_transaction__metadata_at_index_with_item() {
+        configureForReadingSingle()
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result, item.metadata)
+    }
+
+    func test__reader_with_transaction__metadata_at_index_with_no_item() {
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertNil(result)
+    }
+
     func test__reader_with_transaction__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
         let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -319,6 +355,23 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertEqual(result, [])
     }
 
+    func test__reader_with_transaction__metadata_at_indexes_with_items() {
+        configureForReadingMultiple()
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.count, items.map { $0.metadata }.count)
+    }
+
+    func test__reader_with_transaction__metadata_at_indexes_with_no_items() {
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result, [])
+    }
+
     func test__reader_with_transaction__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(readTransaction)
@@ -326,6 +379,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
@@ -340,6 +395,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -372,6 +428,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let (result, missing) = reader.filterExisting(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes.first!, indexes.first!)
         XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
@@ -386,6 +443,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
@@ -396,12 +455,33 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func test__reader_with_connection__metadata_at_index_with_item() {
+        configureForReadingSingle()
+        reader = Read(connection)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result, item.metadata)
+    }
+
+    func test__reader_with_connection__metadata_at_index_with_no_item() {
+        reader = Read(connection)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertNil(result)
+    }
+
     func test__reader_with_connection__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
         let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -413,6 +493,25 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertEqual(result, [])
     }
 
+    func test__reader_with_connection__metadata_at_indexes_with_items() {
+        configureForReadingMultiple()
+        reader = Read(connection)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.count, items.map { $0.metadata }.count)
+    }
+
+    func test__reader_with_connection__metadata_at_indexes_with_no_items() {
+        reader = Read(connection)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result, [])
+    }
+
     func test__reader_with_connection__by_key_with_item() {
         configureForReadingSingle()
         reader = Read(connection)
@@ -421,6 +520,8 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {
@@ -437,6 +538,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -455,6 +557,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Inventory.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -473,6 +576,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
         let (result, missing) = reader.filterExisting(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes.first!, indexes.first!)
         XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }

--- a/Tests/Shared/ValueWithObjectMetadataTests.swift
+++ b/Tests/Shared/ValueWithObjectMetadataTests.swift
@@ -104,10 +104,12 @@ class ValueWithObjectMetadataTests: XCTestCase {
 
     func configureForReadingSingle() {
         readTransaction.object = item.encoded
+        readTransaction.metadata = item.metadata
     }
 
     func configureForReadingMultiple() {
         readTransaction.objects = items.encoded
+        readTransaction.metadatas = items.map { $0.metadata }
         readTransaction.keys = keys
     }
 
@@ -489,6 +491,18 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNil(inventory)
     }
 
+    func test__transaction__read_metadata_at_index_with_data() {
+        configureForReadingSingle()
+        let result: Inventory.MetadataType? = readTransaction.readMetadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!, item.metadata)
+    }
+
+    func test__transaction__read_metadata_at_index_without_data() {
+        let result: Inventory.MetadataType? = readTransaction.readMetadataAtIndex(index)
+        XCTAssertNil(result)
+    }
+
     func test__transaction__read_at_indexes_with_data() {
         configureForReadingMultiple()
         let inventorys: [Inventory] = readTransaction.readAtIndexes(indexes)
@@ -499,6 +513,18 @@ class ValueWithObjectMetadataTests: XCTestCase {
         let inventorys: [Inventory] = readTransaction.readAtIndexes(indexes)
         XCTAssertNotNil(inventorys)
         XCTAssertTrue(inventorys.isEmpty)
+    }
+
+    func test__transaction__read_metadata_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result: [Inventory.MetadataType] = readTransaction.readMetadataAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__transaction__read_metadata_at_indexes_without_data() {
+        let result: [Inventory.MetadataType] = readTransaction.readMetadataAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__transaction__read_by_key_with_data() {
@@ -539,6 +565,18 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertNil(inventory)
     }
 
+    func test__connection__read_metadata_at_index_with_data() {
+        configureForReadingSingle()
+        let result: Inventory.MetadataType? = connection.readMetadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!, item.metadata)
+    }
+
+    func test__connection__read_metadata_at_index_without_data() {
+        let result: Inventory.MetadataType? = connection.readMetadataAtIndex(index)
+        XCTAssertNil(result)
+    }
+
     func test__connection__read_at_indexes_with_data() {
         configureForReadingMultiple()
         let inventorys: [Inventory] = connection.readAtIndexes(indexes)
@@ -549,6 +587,18 @@ class ValueWithObjectMetadataTests: XCTestCase {
         let inventorys: [Inventory] = connection.readAtIndexes(indexes)
         XCTAssertNotNil(inventorys)
         XCTAssertTrue(inventorys.isEmpty)
+    }
+
+    func test__connection__read_metadata_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result: [Inventory.MetadataType] = connection.readMetadataAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__connection__read_metadata_at_indexes_without_data() {
+        let result: [Inventory.MetadataType] = connection.readMetadataAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__connection__read_by_key_with_data() {

--- a/Tests/Shared/ValueWithValueMetadataTests.swift
+++ b/Tests/Shared/ValueWithValueMetadataTests.swift
@@ -102,10 +102,12 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func configureForReadingSingle() {
         readTransaction.object = item.encoded
+        readTransaction.metadata = item.metadata?.encoded
     }
 
     func configureForReadingMultiple() {
         readTransaction.objects = items.encoded
+        readTransaction.metadatas = items.map { $0.metadata?.encoded }
         readTransaction.keys = keys
     }
 
@@ -488,6 +490,18 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNil(product)
     }
 
+    func test__transaction__read_metadata_at_index_with_data() {
+        configureForReadingSingle()
+        let result: Product.MetadataType? = readTransaction.readMetadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!, item.metadata)
+    }
+
+    func test__transaction__read_metadata_at_index_without_data() {
+        let result: Product.MetadataType? = readTransaction.readMetadataAtIndex(index)
+        XCTAssertNil(result)
+    }
+
     func test__transaction__read_at_indexes_with_data() {
         configureForReadingMultiple()
         let products: [Product] = readTransaction.readAtIndexes(indexes)
@@ -498,6 +512,18 @@ class ValueWithValueMetadataTests: XCTestCase {
         let products: [Product] = readTransaction.readAtIndexes(indexes)
         XCTAssertNotNil(products)
         XCTAssertTrue(products.isEmpty)
+    }
+
+    func test__transaction__read_metadata_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result: [Product.MetadataType] = readTransaction.readMetadataAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__transaction__read_metadata_at_indexes_without_data() {
+        let result: [Product.MetadataType] = readTransaction.readMetadataAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__transaction__read_by_key_with_data() {
@@ -538,6 +564,18 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNil(product)
     }
 
+    func test__connection__read_metadata_at_index_with_data() {
+        configureForReadingSingle()
+        let result: Product.MetadataType? = connection.readMetadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!, item.metadata)
+    }
+
+    func test__connection__read_metadata_at_index_without_data() {
+        let result: Product.MetadataType? = connection.readMetadataAtIndex(index)
+        XCTAssertNil(result)
+    }
+
     func test__connection__read_at_indexes_with_data() {
         configureForReadingMultiple()
         let products: [Product] = connection.readAtIndexes(indexes)
@@ -548,6 +586,18 @@ class ValueWithValueMetadataTests: XCTestCase {
         let products: [Product] = connection.readAtIndexes(indexes)
         XCTAssertNotNil(products)
         XCTAssertTrue(products.isEmpty)
+    }
+
+    func test__connection__read_metadata_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result: [Product.MetadataType] = connection.readMetadataAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__connection__read_metadata_at_indexes_without_data() {
+        let result: [Product.MetadataType] = connection.readMetadataAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__connection__read_by_key_with_data() {

--- a/Tests/Shared/ValueWithValueMetadataTests.swift
+++ b/Tests/Shared/ValueWithValueMetadataTests.swift
@@ -194,6 +194,8 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__in_transaction_at_index_2() {
@@ -204,6 +206,8 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__at_index_in_transaction() {
@@ -214,14 +218,17 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__at_indexes_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexesInTransaction(indexes)(readTransaction)
+        let result = reader.atIndexesInTransaction(indexes)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__at_indexes_in_transaction_with_no_items() {
@@ -238,6 +245,8 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__in_transaction_by_key_2() {
@@ -248,6 +257,8 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__by_key_in_transaction() {
@@ -258,23 +269,27 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader__by_keys_in_transaction_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction(keys)(readTransaction)
+        let result = reader.byKeysInTransaction(keys)(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_items_with_no_keys() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeysInTransaction()(readTransaction)
+        let result = reader.byKeysInTransaction()(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(readTransaction.didKeysInCollection!, Product.collection)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader__by_keys_in_transaction_with_no_items() {
@@ -293,6 +308,8 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_transaction__at_index_with_no_item() {
@@ -302,18 +319,54 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func test__reader_with_transaction__metadata_at_index_with_item() {
+        configureForReadingSingle()
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result, item.metadata)
+    }
+
+    func test__reader_with_transaction__metadata_at_index_with_no_item() {
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertNil(result)
+    }
+
     func test__reader_with_transaction__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__at_indexes_with_no_items() {
         reader = Read(readTransaction)
         let result = reader.atIndexes(indexes)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(result, [])
+    }
+
+    func test__reader_with_transaction__metadata_at_indexes_with_items() {
+        configureForReadingMultiple()
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.count, items.map { $0.metadata }.count)
+    }
+
+    func test__reader_with_transaction__metadata_at_indexes_with_no_items() {
+        reader = Read(readTransaction)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result, [])
     }
 
@@ -324,6 +377,8 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_transaction__by_key_with_no_item() {
@@ -336,9 +391,10 @@ class ValueWithValueMetadataTests: XCTestCase {
     func test__reader_with_transaction__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__by_keys_with_no_items() {
@@ -351,10 +407,10 @@ class ValueWithValueMetadataTests: XCTestCase {
     func test__reader_with_transaction__all_with_items() {
         configureForReadingMultiple()
         reader = Read(readTransaction)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertEqual(readTransaction.didKeysInCollection, Product.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_transaction__all_with_no_items() {
@@ -368,9 +424,10 @@ class ValueWithValueMetadataTests: XCTestCase {
     func test__reader_with_transaction__filter() {
         configureForReadingSingle()
         reader = Read(readTransaction)
-        let (items, missing) = reader.filterExisting(keys)
+        let (result, missing) = reader.filterExisting(keys)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
-        XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes.first!, indexes.first!)
+        XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
@@ -384,6 +441,8 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_connection__at_index_with_no_item() {
@@ -394,13 +453,34 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func test__reader_with_connection__metadata_at_index_with_item() {
+        configureForReadingSingle()
+        reader = Read(connection)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result, item.metadata)
+    }
+
+    func test__reader_with_connection__metadata_at_index_with_no_item() {
+        reader = Read(connection)
+        let result = reader.metadataAtIndex(index)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertNil(readTransaction.didReadAtIndex)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertNil(result)
+    }
+
     func test__reader_with_connection__at_indexes_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.atIndexes(indexes)
+        let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__at_indexes_with_no_items() {
@@ -408,6 +488,25 @@ class ValueWithValueMetadataTests: XCTestCase {
         let result = reader.atIndexes(indexes)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
+        XCTAssertEqual(result, [])
+    }
+
+    func test__reader_with_connection__metadata_at_indexes_with_items() {
+        configureForReadingMultiple()
+        reader = Read(connection)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.count, items.map { $0.metadata }.count)
+    }
+
+    func test__reader_with_connection__metadata_at_indexes_with_no_items() {
+        reader = Read(connection)
+        let result = reader.metadataAtIndexes(indexes)
+        XCTAssertTrue(connection.didRead)
+        XCTAssertTrue(readTransaction.didReadAtIndexes.isEmpty)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
         XCTAssertEqual(result, [])
     }
 
@@ -419,6 +518,8 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndex!, index)
         XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndex!, index)
+        XCTAssertEqual(result!.metadata, item.metadata)
     }
 
     func test__reader_with_connection__by_key_with_no_item() {
@@ -432,10 +533,11 @@ class ValueWithValueMetadataTests: XCTestCase {
     func test__reader_with_connection__by_keys_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.byKeys(keys)
+        let result = reader.byKeys(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__by_keys_with_no_items() {
@@ -449,11 +551,12 @@ class ValueWithValueMetadataTests: XCTestCase {
     func test__reader_with_connection__all_with_items() {
         configureForReadingMultiple()
         reader = Read(connection)
-        let items = reader.all()
+        let result = reader.all()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didKeysInCollection, Product.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(items.map { $0.identifier }, items.map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes, indexes)
+        XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
     func test__reader_with_connection__all_with_no_items() {
@@ -468,10 +571,11 @@ class ValueWithValueMetadataTests: XCTestCase {
     func test__reader_with_connection__filter() {
         configureForReadingSingle()
         reader = Read(connection)
-        let (items, missing) = reader.filterExisting(keys)
+        let (result, missing) = reader.filterExisting(keys)
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(readTransaction.didReadAtIndexes.first!, indexes.first!)
-        XCTAssertEqual(items.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
+        XCTAssertEqual(readTransaction.didReadMetadataAtIndexes.first!, indexes.first!)
+        XCTAssertEqual(result.map { $0.identifier }, items.prefixUpTo(1).map { $0.identifier })
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 

--- a/YapDatabaseExtensions.xcodeproj/project.pbxproj
+++ b/YapDatabaseExtensions.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		653B04BF1BC9824100AC98FD /* ValueWithValueMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B04991BC9820A00AC98FD /* ValueWithValueMetadataTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04C01BC9824100AC98FD /* YapDatabaseExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653B049A1BC9820A00AC98FD /* YapDatabaseExtensionsTests.swift */; settings = {ASSET_TAGS = (); }; };
 		653B04C11BC982CC00AC98FD /* YapDatabaseExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 653B04791BC9816D00AC98FD /* YapDatabaseExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		654EAE761BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE751BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		654EAE771BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE751BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		654EAE791BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE781BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		654EAE7A1BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE781BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5578B1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5578C1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5578D1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577E1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
@@ -120,6 +124,8 @@
 		653B04981BC9820A00AC98FD /* ValueWithObjectMetadataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueWithObjectMetadataTests.swift; sourceTree = "<group>"; };
 		653B04991BC9820A00AC98FD /* ValueWithValueMetadataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueWithValueMetadataTests.swift; sourceTree = "<group>"; };
 		653B049A1BC9820A00AC98FD /* YapDatabaseExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YapDatabaseExtensionsTests.swift; sourceTree = "<group>"; };
+		654EAE751BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_AnyWithObjectMetadata.swift; sourceTree = "<group>"; };
+		654EAE781BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_AnyWithValueMetadata.swift; sourceTree = "<group>"; };
 		65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ObjectWithObjectMetadata.swift; sourceTree = "<group>"; };
 		65C5577E1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ObjectWithValueMetadata.swift; sourceTree = "<group>"; };
 		65C5577F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ValueWIthObjectMetadata.swift; sourceTree = "<group>"; };
@@ -265,6 +271,8 @@
 		65C5577C1BCB26010065C96A /* Functional */ = {
 			isa = PBXGroup;
 			children = (
+				654EAE751BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift */,
+				654EAE781BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift */,
 				65C8DB481BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift */,
 				65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */,
 				65C5577E1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift */,
@@ -654,6 +662,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				654EAE791BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift in Sources */,
 				653B04861BC981D100AC98FD /* YapDB.swift in Sources */,
 				65C557A61BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579B1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
@@ -662,6 +671,7 @@
 				65C8DB491BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift in Sources */,
 				65C8DB4C1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift in Sources */,
 				65C8DB421BCD24EA002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */,
+				654EAE761BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift in Sources */,
 				65C557A31BCB26010065C96A /* Write.swift in Sources */,
 				65C557911BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
 				65C5578F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
@@ -697,6 +707,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				654EAE7A1BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift in Sources */,
 				653B048B1BC981D700AC98FD /* YapDB.swift in Sources */,
 				65C557A71BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579C1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
@@ -705,6 +716,7 @@
 				65C8DB4A1BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift in Sources */,
 				65C8DB4D1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift in Sources */,
 				65C8DB431BCD24EB002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */,
+				654EAE771BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift in Sources */,
 				65C557A41BCB26010065C96A /* Write.swift in Sources */,
 				65C557921BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
 				65C557901BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,

--- a/YapDatabaseExtensions.xcodeproj/project.pbxproj
+++ b/YapDatabaseExtensions.xcodeproj/project.pbxproj
@@ -41,6 +41,10 @@
 		654EAE771BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE751BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		654EAE791BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE781BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		654EAE7A1BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE781BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		654EAE7C1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE7B1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		654EAE7D1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE7B1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		654EAE7F1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE7E1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		654EAE801BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE7E1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5578B1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5578C1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5578D1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577E1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
@@ -126,6 +130,8 @@
 		653B049A1BC9820A00AC98FD /* YapDatabaseExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YapDatabaseExtensionsTests.swift; sourceTree = "<group>"; };
 		654EAE751BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_AnyWithObjectMetadata.swift; sourceTree = "<group>"; };
 		654EAE781BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_AnyWithValueMetadata.swift; sourceTree = "<group>"; };
+		654EAE7B1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Persistable_AnyWithObjectMetadata.swift; sourceTree = "<group>"; };
+		654EAE7E1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Persistable_AnyWithValueMetadata.swift; sourceTree = "<group>"; };
 		65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ObjectWithObjectMetadata.swift; sourceTree = "<group>"; };
 		65C5577E1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ObjectWithValueMetadata.swift; sourceTree = "<group>"; };
 		65C5577F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ValueWIthObjectMetadata.swift; sourceTree = "<group>"; };
@@ -287,6 +293,8 @@
 		65C557811BCB26010065C96A /* Persistable */ = {
 			isa = PBXGroup;
 			children = (
+				654EAE7B1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift */,
+				654EAE7E1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift */,
 				65C557821BCB26010065C96A /* Persistable_ObjectWithNoMetadata.swift */,
 				65C557831BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift */,
 				65C557841BCB26010065C96A /* Persistable_ObjectWithValueMetadata.swift */,
@@ -664,6 +672,7 @@
 			files = (
 				654EAE791BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift in Sources */,
 				653B04861BC981D100AC98FD /* YapDB.swift in Sources */,
+				654EAE7F1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift in Sources */,
 				65C557A61BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579B1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
 				65C5579D1BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift in Sources */,
@@ -677,6 +686,7 @@
 				65C5578F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
 				653B04851BC981D100AC98FD /* YapDatabaseExtensions.swift in Sources */,
 				65C557951BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift in Sources */,
+				654EAE7C1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift in Sources */,
 				65C557A11BCB26010065C96A /* Remove.swift in Sources */,
 				65C557971BCB26010065C96A /* Persistable_ObjectWithValueMetadata.swift in Sources */,
 				65C5579F1BCB26010065C96A /* Read.swift in Sources */,
@@ -709,6 +719,7 @@
 			files = (
 				654EAE7A1BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift in Sources */,
 				653B048B1BC981D700AC98FD /* YapDB.swift in Sources */,
+				654EAE801BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift in Sources */,
 				65C557A71BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579C1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
 				65C5579E1BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift in Sources */,
@@ -722,6 +733,7 @@
 				65C557901BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
 				653B048A1BC981D700AC98FD /* YapDatabaseExtensions.swift in Sources */,
 				65C557961BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift in Sources */,
+				654EAE7D1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift in Sources */,
 				65C557A21BCB26010065C96A /* Remove.swift in Sources */,
 				65C557981BCB26010065C96A /* Persistable_ObjectWithValueMetadata.swift in Sources */,
 				65C557A01BCB26010065C96A /* Read.swift in Sources */,

--- a/YapDatabaseExtensions/Shared/Functional/Functional_AnyWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_AnyWithObjectMetadata.swift
@@ -1,0 +1,64 @@
+//
+//  Functional_AnyWithObjectMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 13/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+import YapDatabase
+
+// MARK: - Reading
+
+extension ReadTransactionType {
+
+    /**
+    Reads the metadata at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `MetadataType`
+    */
+    public func readMetadataAtIndex<
+        MetadataType: NSCoding>(index: YapDB.Index) -> MetadataType? {
+            return readMetadataAtIndex(index) as? MetadataType
+    }
+
+    /**
+    Reads the metadata at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `MetadataType`
+    */
+    public func readMetadataAtIndexes<
+        MetadataType: NSCoding>(indexes: [YapDB.Index]) -> [MetadataType] {
+            return indexes.flatMap(readMetadataAtIndex)
+    }
+}
+
+extension ConnectionType {
+
+    /**
+    Reads the metadata at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `MetadataType`
+    */
+    public func readMetadataAtIndex<
+        MetadataType: NSCoding>(index: YapDB.Index) -> MetadataType? {
+            return read { $0.readMetadataAtIndex(index) }
+    }
+
+    /**
+    Reads the metadata at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `MetadataType`
+    */
+    public func readMetadataAtIndexes<
+        MetadataType: NSCoding>(indexes: [YapDB.Index]) -> [MetadataType] {
+            return read { $0.readMetadataAtIndexes(indexes) }
+    }
+}
+

--- a/YapDatabaseExtensions/Shared/Functional/Functional_AnyWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_AnyWithValueMetadata.swift
@@ -1,0 +1,80 @@
+//
+//  Functional_AnyWithValueMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 13/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+import YapDatabase
+
+// MARK: - Reading
+
+extension ReadTransactionType {
+
+    /**
+    Reads the metadata at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `MetadataType`
+    */
+    public func readMetadataAtIndex<
+        MetadataType where
+        MetadataType: ValueCoding,
+        MetadataType.Coder: NSCoding,
+        MetadataType.Coder.ValueType == MetadataType>(index: YapDB.Index) -> MetadataType? {
+            return MetadataType.decode(readMetadataAtIndex(index))
+    }
+
+    /**
+    Reads the metadata at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `MetadataType`
+    */
+    public func readMetadataAtIndexes<
+        MetadataType where
+        MetadataType: ValueCoding,
+        MetadataType.Coder: NSCoding,
+        MetadataType.Coder.ValueType == MetadataType>(indexes: [YapDB.Index]) -> [MetadataType] {
+            return indexes.flatMap(readMetadataAtIndex)
+    }
+}
+
+extension ConnectionType {
+
+    /**
+    Reads the metadata at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `MetadataType`
+    */
+    public func readMetadataAtIndex<
+        MetadataType where
+        MetadataType: ValueCoding,
+        MetadataType.Coder: NSCoding,
+        MetadataType.Coder.ValueType == MetadataType>(index: YapDB.Index) -> MetadataType? {
+            return read { $0.readMetadataAtIndex(index) }
+    }
+
+    /**
+    Reads the metadata at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `MetadataType`
+    */
+    public func readMetadataAtIndexes<
+        MetadataType where
+        MetadataType: ValueCoding,
+        MetadataType.Coder: NSCoding,
+        MetadataType.Coder.ValueType == MetadataType>(indexes: [YapDB.Index]) -> [MetadataType] {
+            return read { $0.readMetadataAtIndexes(indexes) }
+    }
+}
+
+
+
+
+

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
@@ -26,7 +26,7 @@ extension ReadTransactionType {
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(index: YapDB.Index) -> ObjectWithObjectMetadata? {
             if var item = readAtIndex(index) as? ObjectWithObjectMetadata {
-                item.metadata = readMetadataAtIndex(index) as? ObjectWithObjectMetadata.MetadataType
+                item.metadata = readMetadataAtIndex(index)
                 return item
             }
             return .None

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
@@ -47,7 +47,7 @@ extension ReadTransactionType {
     }
 
     /**
-    Reads the item at the key.
+    Reads the item by key.
 
     - parameter key: a String
     - returns: an optional `ItemType`

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithValueMetadata.swift
@@ -28,7 +28,7 @@ extension ReadTransactionType {
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
         ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(index: YapDB.Index) -> ObjectWithValueMetadata? {
             if var item = readAtIndex(index) as? ObjectWithValueMetadata {
-                item.metadata = ObjectWithValueMetadata.MetadataType.decode(readMetadataAtIndex(index))
+                item.metadata = readMetadataAtIndex(index)
                 return item
             }
             return .None

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthObjectMetadata.swift
@@ -28,7 +28,7 @@ extension ReadTransactionType {
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
         ValueWithObjectMetadata.MetadataType: NSCoding>(index: YapDB.Index) -> ValueWithObjectMetadata? {
             if var item = ValueWithObjectMetadata.decode(readAtIndex(index)) {
-                item.metadata = readMetadataAtIndex(index) as? ValueWithObjectMetadata.MetadataType
+                item.metadata = readMetadataAtIndex(index)
                 return item
             }
             return .None

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthValueMetadata.swift
@@ -30,7 +30,7 @@ extension ReadTransactionType {
         ValueWithValueMetadata.MetadataType.Coder: NSCoding,
         ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(index: YapDB.Index) -> ValueWithValueMetadata? {
             if var item = ValueWithValueMetadata.decode(readAtIndex(index)) {
-                item.metadata = ValueWithValueMetadata.MetadataType.decode(readMetadataAtIndex(index))
+                item.metadata = readMetadataAtIndex(index)
                 return item
             }
             return .None

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_AnyWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_AnyWithObjectMetadata.swift
@@ -1,0 +1,57 @@
+//
+//  Persistable_AnyWithObjectMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 13/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+import YapDatabase
+
+// MARK: - Readable
+
+extension Readable where
+    ItemType: Persistable,
+    ItemType.MetadataType: NSCoding {
+
+    func metadataInTransaction(transaction: Database.Connection.ReadTransaction, atIndex index: YapDB.Index) -> ItemType.MetadataType? {
+        return transaction.readMetadataAtIndex(index)
+    }
+
+    func metadataAtIndexInTransaction(index: YapDB.Index) -> Database.Connection.ReadTransaction -> ItemType.MetadataType? {
+        return { self.metadataInTransaction($0, atIndex: index) }
+    }
+
+    func metadataInTransactionAtIndex(transaction: Database.Connection.ReadTransaction) -> YapDB.Index -> ItemType.MetadataType? {
+        return { self.metadataInTransaction(transaction, atIndex: $0) }
+    }
+
+    func metadataAtIndexesInTransaction(indexes: [YapDB.Index]) -> Database.Connection.ReadTransaction -> [ItemType.MetadataType] {
+        let atIndex = metadataInTransactionAtIndex
+        return { transaction in
+            indexes.flatMap(atIndex(transaction))
+        }
+    }
+
+    /**
+    Reads the metadata at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `ItemType.MetadataType`
+    */
+    public func metadataAtIndex(index: YapDB.Index) -> ItemType.MetadataType? {
+        return sync(metadataAtIndexInTransaction(index))
+    }
+
+    /**
+    Reads the metadata at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `ItemType.MetadataType`
+    */
+    public func metadataAtIndexes(indexes: [YapDB.Index]) -> [ItemType.MetadataType] {
+        return sync(metadataAtIndexesInTransaction(indexes))
+    }
+}

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_AnyWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_AnyWithValueMetadata.swift
@@ -1,0 +1,59 @@
+//
+//  Persistable_AnyWithValueMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 13/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+import YapDatabase
+
+// MARK: - Readable
+
+extension Readable where
+    ItemType: Persistable,
+    ItemType.MetadataType: ValueCoding,
+    ItemType.MetadataType.Coder: NSCoding,
+    ItemType.MetadataType.Coder.ValueType == ItemType.MetadataType {
+
+    func metadataInTransaction(transaction: Database.Connection.ReadTransaction, atIndex index: YapDB.Index) -> ItemType.MetadataType? {
+        return transaction.readMetadataAtIndex(index)
+    }
+
+    func metadataAtIndexInTransaction(index: YapDB.Index) -> Database.Connection.ReadTransaction -> ItemType.MetadataType? {
+        return { self.metadataInTransaction($0, atIndex: index) }
+    }
+
+    func metadataInTransactionAtIndex(transaction: Database.Connection.ReadTransaction) -> YapDB.Index -> ItemType.MetadataType? {
+        return { self.metadataInTransaction(transaction, atIndex: $0) }
+    }
+
+    func metadataAtIndexesInTransaction(indexes: [YapDB.Index]) -> Database.Connection.ReadTransaction -> [ItemType.MetadataType] {
+        let atIndex = metadataInTransactionAtIndex
+        return { transaction in
+            indexes.flatMap(atIndex(transaction))
+        }
+    }
+
+    /**
+    Reads the metadata at a given index.
+
+    - parameter index: a YapDB.Index
+    - returns: an optional `ItemType.MetadataType`
+    */
+    public func metadataAtIndex(index: YapDB.Index) -> ItemType.MetadataType? {
+        return sync(metadataAtIndexInTransaction(index))
+    }
+
+    /**
+    Reads the metadata at the indexes.
+
+    - parameter indexes: an Array<YapDB.Index>
+    - returns: an array of `ItemType.MetadataType`
+    */
+    public func metadataAtIndexes(indexes: [YapDB.Index]) -> [ItemType.MetadataType] {
+        return sync(metadataAtIndexesInTransaction(indexes))
+    }
+}

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithNoMetadata.swift
@@ -18,7 +18,7 @@ extension Readable where
     ItemType.MetadataType == Void {
 
     func inTransaction(transaction: Database.Connection.ReadTransaction, atIndex index: YapDB.Index) -> ItemType? {
-        return transaction.readAtIndex(index) as? ItemType
+        return transaction.readAtIndex(index)
     }
 
     // Everything here is the same for all 6 patterns.

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithNoMetadata.swift
@@ -20,7 +20,7 @@ extension Readable where
     ItemType.Coder.ValueType == ItemType {
 
     func inTransaction(transaction: Database.Connection.ReadTransaction, atIndex index: YapDB.Index) -> ItemType? {
-        return ItemType.decode(transaction.readAtIndex(index))
+        return transaction.readAtIndex(index)
     }
 
     // Everything here is the same for all 6 patterns.


### PR DESCRIPTION
Currently I can write my Item without writing its Metadata by setting the metadata property to nil, there's no way to conversely write the Metadata without also writing the Item.

There also doesn't appear to be a way to read either one without reading them both. This may seem odd, given that my original request was that I wanted to be able to read them _together_, which I now can, but I'd still like to be able to read them separately if needed.

Neither of these are really that big of a deal and may just be me prematurely optimizing, but as I'm refactoring my code to use the new API these have come up and I thought I'd run them by you. 
