### PR TITLE
Adds .readAll() function API

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,14 @@ if let item: Item? = connection.readByKey(index) {
 
 let items: [Item] = connection.readByKeys(keys)
 
+let all: [Item] = connection.readAll()
+
 connection.read { transaction in
     let a: Item? = transaction.readAtIndex(index)
     let b: Item? = transaction.readByKey(key)
     let c: [Item] = transaction.readAtIndexes(indexes)
     let d: [Item] = transaction.readByKeys(keys)
+    let all: [Item] = transaction.readAll()
 }
 ```
 

--- a/Tests/Shared/ObjectWithNoMetadataTests.swift
+++ b/Tests/Shared/ObjectWithNoMetadataTests.swift
@@ -514,6 +514,13 @@ class ObjectWithNoMetadataTests: XCTestCase {
         XCTAssertTrue(people.isEmpty)
     }
 
+    func test__transaction__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Person] = readTransaction.readAll()
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
     // Functional API - ConnectionType - Reading
 
     func test__connection__read_at_index_with_data() {
@@ -564,6 +571,14 @@ class ObjectWithNoMetadataTests: XCTestCase {
         let people: [Person] = connection.readByKeys(keys)
         XCTAssertNotNil(people)
         XCTAssertTrue(people.isEmpty)
+    }
+
+    func test__connection__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Person] = connection.readAll()
+        XCTAssertTrue(connection.didRead)
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
     }
 
     // MARK: - Functional API - Transaction - Writing

--- a/Tests/Shared/ObjectWithObjectMetadataTests.swift
+++ b/Tests/Shared/ObjectWithObjectMetadataTests.swift
@@ -637,6 +637,13 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         XCTAssertTrue(employees.isEmpty)
     }
 
+    func test__transaction__read_all_with_data() {
+        configureForReadingMultiple()
+        let employees: [Employee] = readTransaction.readAll()
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(employees.count, items.count)
+    }
+
     // Functional API - ConnectionType - Reading
 
     func test__connection__read_at_index_with_data() {
@@ -711,6 +718,14 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         let employees: [Employee] = connection.readByKeys(keys)
         XCTAssertNotNil(employees)
         XCTAssertTrue(employees.isEmpty)
+    }
+
+    func test__connection__read_all_with_data() {
+        configureForReadingMultiple()
+        let employees: [Employee] = connection.readAll()
+        XCTAssertTrue(connection.didRead)
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(employees.count, items.count)
     }
 
     // MARK: - Functional API - Transaction - Writing

--- a/Tests/Shared/ObjectWithValueMetadataTests.swift
+++ b/Tests/Shared/ObjectWithValueMetadataTests.swift
@@ -635,6 +635,13 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertTrue(managers.isEmpty)
     }
 
+    func test__transaction__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Manager] = readTransaction.readAll()
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
     // Functional API - ConnectionType - Reading
 
     func test__connection__read_at_index_with_data() {
@@ -707,6 +714,14 @@ class ObjectWithValueMetadataTests: XCTestCase {
         let managers: [Manager] = connection.readByKeys(keys)
         XCTAssertNotNil(managers)
         XCTAssertTrue(managers.isEmpty)
+    }
+
+    func test__connection__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Manager] = connection.readAll()
+        XCTAssertTrue(connection.didRead)
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
     }
 
     // MARK: - Functional API - Transaction - Writing

--- a/Tests/Shared/ValueWithNoMetadataTests.swift
+++ b/Tests/Shared/ValueWithNoMetadataTests.swift
@@ -515,6 +515,13 @@ class ValueWithNoMetadataTests: XCTestCase {
         XCTAssertTrue(barcodes.isEmpty)
     }
 
+    func test__transaction__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Barcode] = readTransaction.readAll()
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
     // Functional API - ConnectionType - Reading
 
     func test__connection__read_at_index_with_data() {
@@ -565,6 +572,14 @@ class ValueWithNoMetadataTests: XCTestCase {
         let barcodes: [Barcode] = connection.readByKeys(keys)
         XCTAssertNotNil(barcodes)
         XCTAssertTrue(barcodes.isEmpty)
+    }
+
+    func test__connection__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Barcode] = connection.readAll()
+        XCTAssertTrue(connection.didRead)
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
     }
 
     // MARK: - Functional API - Transaction - Writing

--- a/Tests/Shared/ValueWithObjectMetadataTests.swift
+++ b/Tests/Shared/ValueWithObjectMetadataTests.swift
@@ -655,6 +655,13 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertTrue(inventorys.isEmpty)
     }
 
+    func test__transaction__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Inventory] = readTransaction.readAll()
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
     // Functional API - ConnectionType - Reading
 
     func test__connection__read_at_index_with_data() {
@@ -727,6 +734,14 @@ class ValueWithObjectMetadataTests: XCTestCase {
         let inventorys: [Inventory] = connection.readByKeys(keys)
         XCTAssertNotNil(inventorys)
         XCTAssertTrue(inventorys.isEmpty)
+    }
+
+    func test__connection__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Inventory] = connection.readAll()
+        XCTAssertTrue(connection.didRead)
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
     }
 
     // MARK: - Functional API - Transaction - Writing

--- a/Tests/Shared/ValueWithValueMetadataTests.swift
+++ b/Tests/Shared/ValueWithValueMetadataTests.swift
@@ -654,6 +654,13 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertTrue(products.isEmpty)
     }
 
+    func test__transaction__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Product] = readTransaction.readAll()
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
     // Functional API - ConnectionType - Reading
 
     func test__connection__read_at_index_with_data() {
@@ -726,6 +733,14 @@ class ValueWithValueMetadataTests: XCTestCase {
         let products: [Product] = connection.readByKeys(keys)
         XCTAssertNotNil(products)
         XCTAssertTrue(products.isEmpty)
+    }
+
+    func test__connection__read_all_with_data() {
+        configureForReadingMultiple()
+        let result: [Product] = connection.readAll()
+        XCTAssertTrue(connection.didRead)
+        XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
+        XCTAssertEqual(result.count, items.count)
     }
 
     // MARK: - Functional API - Transaction - Writing

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithNoMetadata.swift
@@ -69,6 +69,19 @@ extension ReadTransactionType {
         ObjectWithNoMetadata.MetadataType == Void>(keys: [String]) -> [ObjectWithNoMetadata] {
             return readAtIndexes(ObjectWithNoMetadata.indexesWithKeys(keys))
     }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>() -> [ObjectWithNoMetadata] {
+            return readByKeys(keysInCollection(ObjectWithNoMetadata.collection))
+    }
 }
 
 extension ConnectionType {
@@ -127,6 +140,19 @@ extension ConnectionType {
         ObjectWithNoMetadata: NSCoding,
         ObjectWithNoMetadata.MetadataType == Void>(keys: [String]) -> [ObjectWithNoMetadata] {
             return readAtIndexes(ObjectWithNoMetadata.indexesWithKeys(keys))
+    }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ObjectWithNoMetadata where
+        ObjectWithNoMetadata: Persistable,
+        ObjectWithNoMetadata: NSCoding,
+        ObjectWithNoMetadata.MetadataType == Void>() -> [ObjectWithNoMetadata] {
+            return read { $0.readAll() }
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
@@ -73,6 +73,19 @@ extension ReadTransactionType {
         ObjectWithObjectMetadata.MetadataType: NSCoding>(keys: [String]) -> [ObjectWithObjectMetadata] {
             return readAtIndexes(ObjectWithObjectMetadata.indexesWithKeys(keys))
     }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ObjectWithObjectMetadata where
+        ObjectWithObjectMetadata: Persistable,
+        ObjectWithObjectMetadata: NSCoding,
+        ObjectWithObjectMetadata.MetadataType: NSCoding>() -> [ObjectWithObjectMetadata] {
+            return readByKeys(keysInCollection(ObjectWithObjectMetadata.collection))
+    }
 }
 
 extension ConnectionType {
@@ -131,6 +144,19 @@ extension ConnectionType {
         ObjectWithObjectMetadata: NSCoding,
         ObjectWithObjectMetadata.MetadataType: NSCoding>(keys: [String]) -> [ObjectWithObjectMetadata] {
             return readAtIndexes(ObjectWithObjectMetadata.indexesWithKeys(keys))
+    }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ObjectWithObjectMetadata where
+        ObjectWithObjectMetadata: Persistable,
+        ObjectWithObjectMetadata: NSCoding,
+        ObjectWithObjectMetadata.MetadataType: NSCoding>() -> [ObjectWithObjectMetadata] {
+            return read { $0.readAll() }
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithValueMetadata.swift
@@ -81,6 +81,21 @@ extension ReadTransactionType {
         ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(keys: [String]) -> [ObjectWithValueMetadata] {
             return readAtIndexes(ObjectWithValueMetadata.indexesWithKeys(keys))
     }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ObjectWithValueMetadata where
+        ObjectWithValueMetadata: Persistable,
+        ObjectWithValueMetadata: NSCoding,
+        ObjectWithValueMetadata.MetadataType: ValueCoding,
+        ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
+        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>() -> [ObjectWithValueMetadata] {
+            return readByKeys(keysInCollection(ObjectWithValueMetadata.collection))
+    }
 }
 
 extension ConnectionType {
@@ -147,6 +162,21 @@ extension ConnectionType {
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
         ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(keys: [String]) -> [ObjectWithValueMetadata] {
             return readAtIndexes(ObjectWithValueMetadata.indexesWithKeys(keys))
+    }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ObjectWithValueMetadata where
+        ObjectWithValueMetadata: Persistable,
+        ObjectWithValueMetadata: NSCoding,
+        ObjectWithValueMetadata.MetadataType: ValueCoding,
+        ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
+        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>() -> [ObjectWithValueMetadata] {
+            return read { $0.readAll() }
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthObjectMetadata.swift
@@ -81,6 +81,21 @@ extension ReadTransactionType {
         ValueWithObjectMetadata.MetadataType: NSCoding>(keys: [String]) -> [ValueWithObjectMetadata] {
             return readAtIndexes(ValueWithObjectMetadata.indexesWithKeys(keys))
     }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ValueWithObjectMetadata where
+        ValueWithObjectMetadata: Persistable,
+        ValueWithObjectMetadata: ValueCoding,
+        ValueWithObjectMetadata.Coder: NSCoding,
+        ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
+        ValueWithObjectMetadata.MetadataType: NSCoding>() -> [ValueWithObjectMetadata] {
+            return readByKeys(keysInCollection(ValueWithObjectMetadata.collection))
+    }
 }
 
 extension ConnectionType {
@@ -147,6 +162,21 @@ extension ConnectionType {
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
         ValueWithObjectMetadata.MetadataType: NSCoding>(keys: [String]) -> [ValueWithObjectMetadata] {
             return readAtIndexes(ValueWithObjectMetadata.indexesWithKeys(keys))
+    }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ValueWithObjectMetadata where
+        ValueWithObjectMetadata: Persistable,
+        ValueWithObjectMetadata: ValueCoding,
+        ValueWithObjectMetadata.Coder: NSCoding,
+        ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
+        ValueWithObjectMetadata.MetadataType: NSCoding>() -> [ValueWithObjectMetadata] {
+            return read { $0.readAll() }
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthValueMetadata.swift
@@ -89,6 +89,23 @@ extension ReadTransactionType {
         ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(keys: [String]) -> [ValueWithValueMetadata] {
             return readAtIndexes(ValueWithValueMetadata.indexesWithKeys(keys))
     }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ValueWithValueMetadata where
+        ValueWithValueMetadata: Persistable,
+        ValueWithValueMetadata: ValueCoding,
+        ValueWithValueMetadata.Coder: NSCoding,
+        ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
+        ValueWithValueMetadata.MetadataType: ValueCoding,
+        ValueWithValueMetadata.MetadataType.Coder: NSCoding,
+        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>() -> [ValueWithValueMetadata] {
+            return readByKeys(keysInCollection(ValueWithValueMetadata.collection))
+    }
 }
 
 extension ConnectionType {
@@ -163,6 +180,23 @@ extension ConnectionType {
         ValueWithValueMetadata.MetadataType.Coder: NSCoding,
         ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(keys: [String]) -> [ValueWithValueMetadata] {
             return readAtIndexes(ValueWithValueMetadata.indexesWithKeys(keys))
+    }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ValueWithValueMetadata where
+        ValueWithValueMetadata: Persistable,
+        ValueWithValueMetadata: ValueCoding,
+        ValueWithValueMetadata.Coder: NSCoding,
+        ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
+        ValueWithValueMetadata.MetadataType: ValueCoding,
+        ValueWithValueMetadata.MetadataType.Coder: NSCoding,
+        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>() -> [ValueWithValueMetadata] {
+            return read { $0.readAll() }
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWithNoMetadata.swift
@@ -77,6 +77,21 @@ extension ReadTransactionType {
         ValueWithNoMetadata.MetadataType == Void>(keys: [String]) -> [ValueWithNoMetadata] {
             return readAtIndexes(ValueWithNoMetadata.indexesWithKeys(keys))
     }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>() -> [ValueWithNoMetadata] {
+            return readByKeys(keysInCollection(ValueWithNoMetadata.collection))
+    }
 }
 
 extension ConnectionType {
@@ -143,6 +158,21 @@ extension ConnectionType {
         ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
         ValueWithNoMetadata.MetadataType == Void>(keys: [String]) -> [ValueWithNoMetadata] {
             return readAtIndexes(ValueWithNoMetadata.indexesWithKeys(keys))
+    }
+
+    /**
+    Reads all the items in the database.
+
+    - returns: an array of `ItemType`
+    */
+    public func readAll<
+        ValueWithNoMetadata where
+        ValueWithNoMetadata: Persistable,
+        ValueWithNoMetadata: ValueCoding,
+        ValueWithNoMetadata.Coder: NSCoding,
+        ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
+        ValueWithNoMetadata.MetadataType == Void>() -> [ValueWithNoMetadata] {
+            return read { $0.readAll() }
     }
 }
 


### PR DESCRIPTION
Using the Functional sub-spec I don't have access to the `all` property and have to fallback to using YapDB's `allKeysInCollection` along with `readByKeys`
