### PR TITLE
Return the result of writes for Functional API

### DIFF
--- a/Tests/Shared/ObjectWithNoMetadataTests.swift
+++ b/Tests/Shared/ObjectWithNoMetadataTests.swift
@@ -623,7 +623,7 @@ class ObjectWithNoMetadataTests: XCTestCase {
 
     func test__connection__async_write_item() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(item) { expectation.fulfill() }
+        connection.asyncWrite(item) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)
@@ -635,7 +635,7 @@ class ObjectWithNoMetadataTests: XCTestCase {
 
     func test__connection__async_write_items() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(items) { expectation.fulfill() }
+        connection.asyncWrite(items) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)

--- a/Tests/Shared/ObjectWithObjectMetadataTests.swift
+++ b/Tests/Shared/ObjectWithObjectMetadataTests.swift
@@ -770,7 +770,7 @@ class ObjectWithObjectMetadataTests: XCTestCase {
 
     func test__connection__async_write_item() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(item) { expectation.fulfill() }
+        connection.asyncWrite(item) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)
@@ -782,7 +782,7 @@ class ObjectWithObjectMetadataTests: XCTestCase {
 
     func test__connection__async_write_items() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(items) { expectation.fulfill() }
+        connection.asyncWrite(items) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)

--- a/Tests/Shared/ObjectWithValueMetadataTests.swift
+++ b/Tests/Shared/ObjectWithValueMetadataTests.swift
@@ -766,7 +766,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
 
     func test__connection__async_write_item() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(item) { expectation.fulfill() }
+        connection.asyncWrite(item) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)
@@ -778,7 +778,7 @@ class ObjectWithValueMetadataTests: XCTestCase {
 
     func test__connection__async_write_items() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(items) { expectation.fulfill() }
+        connection.asyncWrite(items) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)

--- a/Tests/Shared/Support.swift
+++ b/Tests/Shared/Support.swift
@@ -135,10 +135,10 @@ extension TestableConnection: ConnectionType {
         }
     }
 
-    func asyncWrite<T>(block: TestableWriteTransaction -> T, queue: dispatch_queue_t, completion: (T) -> Void) {
+    func asyncWrite<T>(block: TestableWriteTransaction -> T, queue: dispatch_queue_t, completion: (T -> Void)? = .None) {
         didAsyncWrite = true
         dispatch_async(queue) { [transaction = self.writeTransaction] in
-            completion(block(transaction))
+            completion?(block(transaction))
         }
     }
 

--- a/Tests/Shared/ValueWithNoMetadataTests.swift
+++ b/Tests/Shared/ValueWithNoMetadataTests.swift
@@ -624,7 +624,7 @@ class ValueWithNoMetadataTests: XCTestCase {
 
     func test__connection__async_write_item() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(item) { expectation.fulfill() }
+        connection.asyncWrite(item) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)
@@ -636,7 +636,7 @@ class ValueWithNoMetadataTests: XCTestCase {
 
     func test__connection__async_write_items() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(items) { expectation.fulfill() }
+        connection.asyncWrite(items) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)

--- a/Tests/Shared/ValueWithObjectMetadataTests.swift
+++ b/Tests/Shared/ValueWithObjectMetadataTests.swift
@@ -786,7 +786,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
 
     func test__connection__async_write_item() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(item) { expectation.fulfill() }
+        connection.asyncWrite(item) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)
@@ -798,7 +798,7 @@ class ValueWithObjectMetadataTests: XCTestCase {
 
     func test__connection__async_write_items() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(items) { expectation.fulfill() }
+        connection.asyncWrite(items) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)

--- a/Tests/Shared/ValueWithValueMetadataTests.swift
+++ b/Tests/Shared/ValueWithValueMetadataTests.swift
@@ -785,7 +785,7 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__connection__async_write_item() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(item) { expectation.fulfill() }
+        connection.asyncWrite(item) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)
@@ -797,7 +797,7 @@ class ValueWithValueMetadataTests: XCTestCase {
 
     func test__connection__async_write_items() {
         let expectation = expectationWithDescription("Test: \(__FUNCTION__)")
-        connection.asyncWrite(items) { expectation.fulfill() }
+        connection.asyncWrite(items) { _ in expectation.fulfill() }
 
         waitForExpectationsWithTimeout(3.0, handler: nil)
         XCTAssertTrue(connection.didAsyncWrite)

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithNoMetadata.swift
@@ -172,19 +172,22 @@ extension WriteTransactionType {
     Write the item to the database using the transaction.
 
     - parameter item: the item to store.
+    - returns: the same item
     */
     public func write<
         ObjectWithNoMetadata where
         ObjectWithNoMetadata: Persistable,
         ObjectWithNoMetadata: NSCoding,
-        ObjectWithNoMetadata.MetadataType == Void>(item: ObjectWithNoMetadata) {
+        ObjectWithNoMetadata.MetadataType == Void>(item: ObjectWithNoMetadata) -> ObjectWithNoMetadata {
             writeAtIndex(item.index, object: item, metadata: .None)
+            return item
     }
 
     /**
     Write the items to the database using the transaction.
 
     - parameter items: a SequenceType of items to store.
+    - returns: the same items, in an array.
     */
     public func write<
         Items, ObjectWithNoMetadata where
@@ -192,8 +195,8 @@ extension WriteTransactionType {
         Items.Generator.Element == ObjectWithNoMetadata,
         ObjectWithNoMetadata: Persistable,
         ObjectWithNoMetadata: NSCoding,
-        ObjectWithNoMetadata.MetadataType == Void>(items: Items) {
-            items.forEach(write)
+        ObjectWithNoMetadata.MetadataType == Void>(items: Items) -> [ObjectWithNoMetadata] {
+            return items.map(write)
     }
 }
 
@@ -203,19 +206,21 @@ extension ConnectionType {
     Write the item to the database synchronously using the connection in a new transaction.
 
     - parameter item: the item to store.
+    - returns: the same item
     */
     public func write<
         ObjectWithNoMetadata where
         ObjectWithNoMetadata: Persistable,
         ObjectWithNoMetadata: NSCoding,
-        ObjectWithNoMetadata.MetadataType == Void>(item: ObjectWithNoMetadata) {
-            write { $0.write(item) }
+        ObjectWithNoMetadata.MetadataType == Void>(item: ObjectWithNoMetadata) -> ObjectWithNoMetadata {
+            return write { $0.write(item) }
     }
 
     /**
     Write the items to the database synchronously using the connection in a new transaction.
 
     - parameter items: a SequenceType of items to store.
+    - returns: the same items, in an array.
     */
     public func write<
         Items, ObjectWithNoMetadata where
@@ -223,8 +228,8 @@ extension ConnectionType {
         Items.Generator.Element == ObjectWithNoMetadata,
         ObjectWithNoMetadata: Persistable,
         ObjectWithNoMetadata: NSCoding,
-        ObjectWithNoMetadata.MetadataType == Void>(items: Items) {
-            write { $0.write(items) }
+        ObjectWithNoMetadata.MetadataType == Void>(items: Items) -> [ObjectWithNoMetadata] {
+            return write { $0.write(items) }
     }
 
     /**
@@ -238,8 +243,8 @@ extension ConnectionType {
         ObjectWithNoMetadata where
         ObjectWithNoMetadata: Persistable,
         ObjectWithNoMetadata: NSCoding,
-        ObjectWithNoMetadata.MetadataType == Void>(item: ObjectWithNoMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(item) }, queue: queue, completion: { _ in completion?() })
+        ObjectWithNoMetadata.MetadataType == Void>(item: ObjectWithNoMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ObjectWithNoMetadata -> Void)? = .None) {
+            asyncWrite({ $0.write(item) }, queue: queue, completion: completion)
     }
 
     /**
@@ -255,8 +260,8 @@ extension ConnectionType {
         Items.Generator.Element == ObjectWithNoMetadata,
         ObjectWithNoMetadata: Persistable,
         ObjectWithNoMetadata: NSCoding,
-        ObjectWithNoMetadata.MetadataType == Void>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(items) }, queue: queue, completion: { _ in completion?() })
+        ObjectWithNoMetadata.MetadataType == Void>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ObjectWithNoMetadata] -> Void)? = .None) {
+            asyncWrite({ $0.write(items) }, queue: queue, completion: completion)
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithObjectMetadata.swift
@@ -181,8 +181,9 @@ extension WriteTransactionType {
         ObjectWithObjectMetadata where
         ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
-        ObjectWithObjectMetadata.MetadataType: NSCoding>(item: ObjectWithObjectMetadata) {
+        ObjectWithObjectMetadata.MetadataType: NSCoding>(item: ObjectWithObjectMetadata) -> ObjectWithObjectMetadata {
             writeAtIndex(item.index, object: item, metadata: item.metadata)
+            return item
     }
 
     /**
@@ -196,8 +197,8 @@ extension WriteTransactionType {
         Items.Generator.Element == ObjectWithObjectMetadata,
         ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
-        ObjectWithObjectMetadata.MetadataType: NSCoding>(items: Items) {
-            items.forEach(write)
+        ObjectWithObjectMetadata.MetadataType: NSCoding>(items: Items) -> [ObjectWithObjectMetadata] {
+            return items.map(write)
     }
 }
 
@@ -212,8 +213,8 @@ extension ConnectionType {
         ObjectWithObjectMetadata where
         ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
-        ObjectWithObjectMetadata.MetadataType: NSCoding>(item: ObjectWithObjectMetadata) {
-            write { $0.write(item) }
+        ObjectWithObjectMetadata.MetadataType: NSCoding>(item: ObjectWithObjectMetadata) -> ObjectWithObjectMetadata {
+            return write { $0.write(item) }
     }
 
     /**
@@ -227,8 +228,8 @@ extension ConnectionType {
         Items.Generator.Element == ObjectWithObjectMetadata,
         ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
-        ObjectWithObjectMetadata.MetadataType: NSCoding>(items: Items) {
-            write { $0.write(items) }
+        ObjectWithObjectMetadata.MetadataType: NSCoding>(items: Items) -> [ObjectWithObjectMetadata] {
+            return write { $0.write(items) }
     }
 
     /**
@@ -242,8 +243,8 @@ extension ConnectionType {
         ObjectWithObjectMetadata where
         ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
-        ObjectWithObjectMetadata.MetadataType: NSCoding>(item: ObjectWithObjectMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(item) }, queue: queue, completion: { _ in completion?() })
+        ObjectWithObjectMetadata.MetadataType: NSCoding>(item: ObjectWithObjectMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ObjectWithObjectMetadata -> Void)? = .None) {
+            asyncWrite({ $0.write(item) }, queue: queue, completion: completion)
     }
 
     /**
@@ -259,8 +260,8 @@ extension ConnectionType {
         Items.Generator.Element == ObjectWithObjectMetadata,
         ObjectWithObjectMetadata: Persistable,
         ObjectWithObjectMetadata: NSCoding,
-        ObjectWithObjectMetadata.MetadataType: NSCoding>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(items) }, queue: queue, completion: { _ in completion?() })
+        ObjectWithObjectMetadata.MetadataType: NSCoding>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ObjectWithObjectMetadata] -> Void)? = .None) {
+            asyncWrite({ $0.write(items) }, queue: queue, completion: completion)
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ObjectWithValueMetadata.swift
@@ -203,8 +203,9 @@ extension WriteTransactionType {
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
-        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(item: ObjectWithValueMetadata) {
+        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(item: ObjectWithValueMetadata) -> ObjectWithValueMetadata {
             writeAtIndex(item.index, object: item, metadata: item.metadata?.encoded)
+            return item
     }
 
     /**
@@ -220,8 +221,8 @@ extension WriteTransactionType {
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
-        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(items: Items) {
-            items.forEach(write)
+        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(items: Items) -> [ObjectWithValueMetadata] {
+            return items.map(write)
     }
 }
 
@@ -238,8 +239,8 @@ extension ConnectionType {
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
-        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(item: ObjectWithValueMetadata) {
-            write { $0.write(item) }
+        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(item: ObjectWithValueMetadata) -> ObjectWithValueMetadata {
+            return write { $0.write(item) }
     }
 
     /**
@@ -255,8 +256,8 @@ extension ConnectionType {
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
-        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(items: Items) {
-            write { $0.write(items) }
+        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(items: Items) -> [ObjectWithValueMetadata] {
+            return write { $0.write(items) }
     }
 
     /**
@@ -272,8 +273,8 @@ extension ConnectionType {
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
-        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(item: ObjectWithValueMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(item) }, queue: queue, completion: { _ in completion?() })
+        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(item: ObjectWithValueMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ObjectWithValueMetadata -> Void)? = .None) {
+            asyncWrite({ $0.write(item) }, queue: queue, completion: completion)
     }
 
     /**
@@ -291,8 +292,8 @@ extension ConnectionType {
         ObjectWithValueMetadata: NSCoding,
         ObjectWithValueMetadata.MetadataType: ValueCoding,
         ObjectWithValueMetadata.MetadataType.Coder: NSCoding,
-        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(items) }, queue: queue, completion: { _ in completion?() })
+        ObjectWithValueMetadata.MetadataType.Coder.ValueType == ObjectWithValueMetadata.MetadataType>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ObjectWithValueMetadata] -> Void)? = .None) {
+            asyncWrite({ $0.write(items) }, queue: queue, completion: completion)
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthObjectMetadata.swift
@@ -203,8 +203,9 @@ extension WriteTransactionType {
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
-        ValueWithObjectMetadata.MetadataType: NSCoding>(item: ValueWithObjectMetadata) {
+        ValueWithObjectMetadata.MetadataType: NSCoding>(item: ValueWithObjectMetadata) -> ValueWithObjectMetadata {
             writeAtIndex(item.index, object: item.encoded, metadata: item.metadata)
+            return item
     }
 
     /**
@@ -220,8 +221,8 @@ extension WriteTransactionType {
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
-        ValueWithObjectMetadata.MetadataType: NSCoding>(items: Items) {
-            items.forEach(write)
+        ValueWithObjectMetadata.MetadataType: NSCoding>(items: Items) -> [ValueWithObjectMetadata] {
+            return items.map(write)
     }
 }
 
@@ -238,8 +239,8 @@ extension ConnectionType {
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
-        ValueWithObjectMetadata.MetadataType: NSCoding>(item: ValueWithObjectMetadata) {
-            write { $0.write(item) }
+        ValueWithObjectMetadata.MetadataType: NSCoding>(item: ValueWithObjectMetadata) -> ValueWithObjectMetadata {
+            return write { $0.write(item) }
     }
 
     /**
@@ -255,8 +256,8 @@ extension ConnectionType {
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
-        ValueWithObjectMetadata.MetadataType: NSCoding>(items: Items) {
-            write { $0.write(items) }
+        ValueWithObjectMetadata.MetadataType: NSCoding>(items: Items) -> [ValueWithObjectMetadata] {
+            return write { $0.write(items) }
     }
 
     /**
@@ -272,8 +273,8 @@ extension ConnectionType {
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
-        ValueWithObjectMetadata.MetadataType: NSCoding>(item: ValueWithObjectMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(item) }, queue: queue, completion: { _ in completion?() })
+        ValueWithObjectMetadata.MetadataType: NSCoding>(item: ValueWithObjectMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ValueWithObjectMetadata -> Void)? = .None) {
+            asyncWrite({ $0.write(item) }, queue: queue, completion: completion)
     }
 
     /**
@@ -291,8 +292,8 @@ extension ConnectionType {
         ValueWithObjectMetadata: ValueCoding,
         ValueWithObjectMetadata.Coder: NSCoding,
         ValueWithObjectMetadata.Coder.ValueType == ValueWithObjectMetadata,
-        ValueWithObjectMetadata.MetadataType: NSCoding>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(items) }, queue: queue, completion: { _ in completion?() })
+        ValueWithObjectMetadata.MetadataType: NSCoding>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ValueWithObjectMetadata] -> Void)? = .None) {
+            asyncWrite({ $0.write(items) }, queue: queue, completion: completion)
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWIthValueMetadata.swift
@@ -217,8 +217,9 @@ extension WriteTransactionType {
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
         ValueWithValueMetadata.MetadataType: ValueCoding,
         ValueWithValueMetadata.MetadataType.Coder: NSCoding,
-        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(item: ValueWithValueMetadata) {
+        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(item: ValueWithValueMetadata) -> ValueWithValueMetadata {
             writeAtIndex(item.index, object: item.encoded, metadata: item.metadata?.encoded)
+            return item
     }
 
     /**
@@ -234,8 +235,8 @@ extension WriteTransactionType {
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
         ValueWithValueMetadata.MetadataType: ValueCoding,
         ValueWithValueMetadata.MetadataType.Coder: NSCoding,
-        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(items: [ValueWithValueMetadata]) {
-            items.forEach(write)
+        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(items: [ValueWithValueMetadata]) -> [ValueWithValueMetadata] {
+            return items.map(write)
     }
 }
 
@@ -254,8 +255,8 @@ extension ConnectionType {
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
         ValueWithValueMetadata.MetadataType: ValueCoding,
         ValueWithValueMetadata.MetadataType.Coder: NSCoding,
-        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(item: ValueWithValueMetadata) {
-            write { $0.write(item) }
+        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(item: ValueWithValueMetadata) -> ValueWithValueMetadata {
+            return write { $0.write(item) }
     }
 
     /**
@@ -271,8 +272,8 @@ extension ConnectionType {
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
         ValueWithValueMetadata.MetadataType: ValueCoding,
         ValueWithValueMetadata.MetadataType.Coder: NSCoding,
-        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(items: [ValueWithValueMetadata]) {
-            write { $0.write(items) }
+        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(items: [ValueWithValueMetadata]) -> [ValueWithValueMetadata] {
+            return write { $0.write(items) }
     }
 
     /**
@@ -290,8 +291,8 @@ extension ConnectionType {
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
         ValueWithValueMetadata.MetadataType: ValueCoding,
         ValueWithValueMetadata.MetadataType.Coder: NSCoding,
-        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(item: ValueWithValueMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(item) }, queue: queue, completion: { _ in completion?() })
+        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(item: ValueWithValueMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ValueWithValueMetadata -> Void)? = .None) {
+            asyncWrite({ $0.write(item) }, queue: queue, completion: completion)
     }
 
     /**
@@ -309,8 +310,8 @@ extension ConnectionType {
         ValueWithValueMetadata.Coder.ValueType == ValueWithValueMetadata,
         ValueWithValueMetadata.MetadataType: ValueCoding,
         ValueWithValueMetadata.MetadataType.Coder: NSCoding,
-        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(items: [ValueWithValueMetadata], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(items) }, queue: queue, completion: { _ in completion?() })
+        ValueWithValueMetadata.MetadataType.Coder.ValueType == ValueWithValueMetadata.MetadataType>(items: [ValueWithValueMetadata], queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ValueWithValueMetadata] -> Void)? = .None) {
+            asyncWrite({ $0.write(items) }, queue: queue, completion: completion)
     }
 }
 

--- a/YapDatabaseExtensions/Shared/Functional/Functional_ValueWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Functional/Functional_ValueWithNoMetadata.swift
@@ -199,8 +199,9 @@ extension WriteTransactionType {
         ValueWithNoMetadata: ValueCoding,
         ValueWithNoMetadata.Coder: NSCoding,
         ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
-        ValueWithNoMetadata.MetadataType == Void>(item: ValueWithNoMetadata) {
+        ValueWithNoMetadata.MetadataType == Void>(item: ValueWithNoMetadata) -> ValueWithNoMetadata {
             writeAtIndex(item.index, object: item.encoded, metadata: .None)
+            return item
     }
 
     /**
@@ -216,8 +217,8 @@ extension WriteTransactionType {
         ValueWithNoMetadata: ValueCoding,
         ValueWithNoMetadata.Coder: NSCoding,
         ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
-        ValueWithNoMetadata.MetadataType == Void>(items: Items) {
-            items.forEach(write)
+        ValueWithNoMetadata.MetadataType == Void>(items: Items) -> [ValueWithNoMetadata] {
+            return items.map(write)
     }
 }
 
@@ -234,8 +235,8 @@ extension ConnectionType {
         ValueWithNoMetadata: ValueCoding,
         ValueWithNoMetadata.Coder: NSCoding,
         ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
-        ValueWithNoMetadata.MetadataType == Void>(item: ValueWithNoMetadata) {
-            write { $0.write(item) }
+        ValueWithNoMetadata.MetadataType == Void>(item: ValueWithNoMetadata) -> ValueWithNoMetadata {
+            return write { $0.write(item) }
     }
 
     /**
@@ -251,8 +252,8 @@ extension ConnectionType {
         ValueWithNoMetadata: ValueCoding,
         ValueWithNoMetadata.Coder: NSCoding,
         ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
-        ValueWithNoMetadata.MetadataType == Void>(items: Items) {
-            write { $0.write(items) }
+        ValueWithNoMetadata.MetadataType == Void>(items: Items) -> [ValueWithNoMetadata] {
+            return write { $0.write(items) }
     }
 
     /**
@@ -268,8 +269,8 @@ extension ConnectionType {
         ValueWithNoMetadata: ValueCoding,
         ValueWithNoMetadata.Coder: NSCoding,
         ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
-        ValueWithNoMetadata.MetadataType == Void>(item: ValueWithNoMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(item) }, queue: queue, completion: { _ in completion?() })
+        ValueWithNoMetadata.MetadataType == Void>(item: ValueWithNoMetadata, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (ValueWithNoMetadata -> Void)? = .None) {
+            asyncWrite({ $0.write(item) }, queue: queue, completion: completion)
     }
 
     /**
@@ -287,8 +288,8 @@ extension ConnectionType {
         ValueWithNoMetadata: ValueCoding,
         ValueWithNoMetadata.Coder: NSCoding,
         ValueWithNoMetadata.Coder.ValueType == ValueWithNoMetadata,
-        ValueWithNoMetadata.MetadataType == Void>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: dispatch_block_t? = .None) {
-            asyncWrite({ $0.write(items) }, queue: queue, completion: { _ in completion?() })
+        ValueWithNoMetadata.MetadataType == Void>(items: Items, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: ([ValueWithNoMetadata] -> Void)? = .None) {
+            asyncWrite({ $0.write(items) }, queue: queue, completion: completion)
     }
 }
 

--- a/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
+++ b/YapDatabaseExtensions/Shared/YapDatabaseExtensions.swift
@@ -360,7 +360,7 @@ public protocol ConnectionType {
     - parameter queue: a dispatch_queue_t, defaults to main queue, can be ommitted in most cases.
     - parameter completion: a closure which receives T and returns Void.
     */
-    func asyncWrite<T>(block: WriteTransaction -> T, queue: dispatch_queue_t, completion: (T) -> Void)
+    func asyncWrite<T>(block: WriteTransaction -> T, queue: dispatch_queue_t, completion: (T -> Void)?)
 
     /**
     Execute a read/write block inside a `NSOperation`. The block argument receives a
@@ -516,9 +516,9 @@ extension YapDatabaseConnection: ConnectionType {
     - parameter queue: a dispatch_queue_t, defaults to main queue, can be ommitted in most cases.
     - parameter completion: a closure which receives T and returns Void.
     */
-    public func asyncWrite<T>(block: YapDatabaseReadWriteTransaction -> T, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (T) -> Void) {
+    public func asyncWrite<T>(block: YapDatabaseReadWriteTransaction -> T, queue: dispatch_queue_t = dispatch_get_main_queue(), completion: (T -> Void)?) {
         var result: T! = .None
-        asyncReadWriteWithBlock({ result = block($0) }, completionQueue: queue) { completion(result) }
+        asyncReadWriteWithBlock({ result = block($0) }, completionQueue: queue) { completion?(result) }
     }
 
     /**


### PR DESCRIPTION
This was the previous behavior. Can we make it work for the Persistable API?
