### PR TITLE
Add Curried API

### DIFF
--- a/Tests/Shared/ObjectWithNoMetadataTests.swift
+++ b/Tests/Shared/ObjectWithNoMetadataTests.swift
@@ -464,6 +464,71 @@ class ObjectWithNoMetadataTests: XCTestCase {
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
+    // Persistable Curried API - Reading
+
+    func test__curried__read_at_index_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertNil(result!.metadata)
+    }
+
+    func test__curried__read_at_index_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_at_indexes_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test__curried__read_by_key_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertNil(result!.metadata)
+    }
+
+    func test__curried__read_by_key_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_by_keys_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // Persistable Curried API - Writing
+
+    func test__curried__writeOn() {
+        let result = connection.write(item.writeOn())
+
+        XCTAssertTrue(connection.didWrite)        
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].1.identifier, item.identifier)
+        XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
+        XCTAssertEqual(result, item)
+    }
+
     // Functional API - ReadTransactionType - Reading
 
     func test__transaction__read_at_index_with_data() {

--- a/Tests/Shared/ObjectWithObjectMetadataTests.swift
+++ b/Tests/Shared/ObjectWithObjectMetadataTests.swift
@@ -563,6 +563,71 @@ class ObjectWithObjectMetadataTests: XCTestCase {
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
+    // Persistable Curried API - Reading
+
+    func test__curried__read_at_index_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(result!.metadata, item.metadata)
+    }
+
+    func test__curried__read_at_index_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_at_indexes_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test__curried__read_by_key_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(result!.metadata, item.metadata)
+    }
+
+    func test__curried__read_by_key_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_by_keys_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // Persistable Curried API - Writing
+
+    func test__curried__writeOn() {
+        let result = connection.write(item.writeOn())
+
+        XCTAssertTrue(connection.didWrite)        
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].1.identifier, item.identifier)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].2 as? NSDate, item.metadata)
+        XCTAssertEqual(result, item)
+    }
+
     // Functional API - ReadTransactionType - Reading
 
     func test__transaction__read_at_index_with_data() {

--- a/Tests/Shared/ObjectWithValueMetadataTests.swift
+++ b/Tests/Shared/ObjectWithValueMetadataTests.swift
@@ -563,6 +563,71 @@ class ObjectWithValueMetadataTests: XCTestCase {
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
+    // Persistable Curried API - Reading
+
+    func test__curried__read_at_index_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(result!.metadata, item.metadata)
+    }
+
+    func test__curried__read_at_index_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_at_indexes_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test__curried__read_by_key_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(result!.metadata, item.metadata)
+    }
+
+    func test__curried__read_by_key_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_by_keys_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // Persistable Curried API - Writing
+
+    func test__curried__writeOn() {
+        let result = connection.write(item.writeOn())
+
+        XCTAssertTrue(connection.didWrite)        
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].1.identifier, item.identifier)
+        XCTAssertEqual(TypeUnderTest.MetadataType.decode(writeTransaction.didWriteAtIndexes[0].2), item.metadata)
+        XCTAssertEqual(result, item)
+    }
+
     // Functional API - ReadTransactionType - Reading
 
     func test__transaction__read_at_index_with_data() {

--- a/Tests/Shared/ValueWithNoMetadataTests.swift
+++ b/Tests/Shared/ValueWithNoMetadataTests.swift
@@ -13,11 +13,13 @@ import ValueCoding
 
 class ValueWithNoMetadataTests: XCTestCase {
 
-    var item: Barcode!
+    typealias TypeUnderTest = Barcode
+
+    var item: TypeUnderTest!
     var index: YapDB.Index!
     var key: String!
 
-    var items: [Barcode]!
+    var items: [TypeUnderTest]!
     var indexes: [YapDB.Index]!
     var keys: [String]!
 
@@ -26,8 +28,8 @@ class ValueWithNoMetadataTests: XCTestCase {
     var writeTransaction: TestableWriteTransaction!
     var readTransaction: TestableReadTransaction!
 
-    var reader: Read<Barcode, TestableDatabase>!
-    var writer: Write<Barcode, TestableDatabase>!
+    var reader: Read<TypeUnderTest, TestableDatabase>!
+    var writer: Write<TypeUnderTest, TestableDatabase>!
 
     var dispatchQueue: dispatch_queue_t!
     var operationQueue: NSOperationQueue!
@@ -121,7 +123,7 @@ class ValueWithNoMetadataTests: XCTestCase {
 
         XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
         XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
-        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
         XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
     }
 
@@ -132,7 +134,7 @@ class ValueWithNoMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didWrite)
         XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
         XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
-        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
         XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
     }
 
@@ -149,7 +151,7 @@ class ValueWithNoMetadataTests: XCTestCase {
         XCTAssertFalse(connection.didWrite)
         XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
         XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
-        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
         XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
     }
 
@@ -169,7 +171,7 @@ class ValueWithNoMetadataTests: XCTestCase {
         XCTAssertFalse(connection.didAsyncWrite)
         XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
         XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
-        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
         XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
     }
 
@@ -261,7 +263,7 @@ class ValueWithNoMetadataTests: XCTestCase {
         reader = Read(readTransaction)
         let result = reader.byKeysInTransaction()(readTransaction)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
-        XCTAssertEqual(readTransaction.didKeysInCollection!, Barcode.collection)
+        XCTAssertEqual(readTransaction.didKeysInCollection!, TypeUnderTest.collection)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
 
@@ -340,7 +342,7 @@ class ValueWithNoMetadataTests: XCTestCase {
         configureForReadingMultiple()
         reader = Read(readTransaction)
         let result = reader.all()
-        XCTAssertEqual(readTransaction.didKeysInCollection, Barcode.collection)
+        XCTAssertEqual(readTransaction.didKeysInCollection, TypeUnderTest.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
@@ -348,7 +350,7 @@ class ValueWithNoMetadataTests: XCTestCase {
     func test__reader_with_transaction__all_with_no_items() {
         reader = Read(readTransaction)
         let result = reader.all()
-        XCTAssertEqual(readTransaction.didKeysInCollection, Barcode.collection)
+        XCTAssertEqual(readTransaction.didKeysInCollection, TypeUnderTest.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
         XCTAssertEqual(result, [])
     }
@@ -439,7 +441,7 @@ class ValueWithNoMetadataTests: XCTestCase {
         reader = Read(connection)
         let result = reader.all()
         XCTAssertTrue(connection.didRead)
-        XCTAssertEqual(readTransaction.didKeysInCollection, Barcode.collection)
+        XCTAssertEqual(readTransaction.didKeysInCollection, TypeUnderTest.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, indexes)
         XCTAssertEqual(result.map { $0.identifier }, items.map { $0.identifier })
     }
@@ -448,7 +450,7 @@ class ValueWithNoMetadataTests: XCTestCase {
         reader = Read(connection)
         let result = reader.all()
         XCTAssertTrue(connection.didRead)
-        XCTAssertEqual(readTransaction.didKeysInCollection, Barcode.collection)
+        XCTAssertEqual(readTransaction.didKeysInCollection, TypeUnderTest.collection)
         XCTAssertEqual(readTransaction.didReadAtIndexes, [])
         XCTAssertEqual(result, [])
     }
@@ -463,61 +465,126 @@ class ValueWithNoMetadataTests: XCTestCase {
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
+    // Persistable Curried API - Reading
+
+    func test__curried__read_at_index_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertNil(result!.metadata)
+    }
+
+    func test__curried__read_at_index_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_at_indexes_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test__curried__read_by_key_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertNil(result!.metadata)
+    }
+
+    func test__curried__read_by_key_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_by_keys_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // Persistable Curried API - Writing
+
+    func test__curried__writeOn() {
+        let result = connection.write(item.writeOn())
+
+        XCTAssertTrue(connection.didWrite)        
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
+        XCTAssertEqual(result, item)
+    }
+
     // Functional API - ReadTransactionType - Reading
 
     func test__transaction__read_at_index_with_data() {
         configureForReadingSingle()
-        let barcode: Barcode? = readTransaction.readAtIndex(index)
-        XCTAssertNotNil(barcode)
-        XCTAssertEqual(barcode!.identifier, item.identifier)
-        XCTAssertNil(barcode!.metadata)
+        let result: TypeUnderTest? = readTransaction.readAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertNil(result!.metadata)
     }
 
     func test__transaction__read_at_index_without_data() {
-        let barcode: Barcode? = readTransaction.readAtIndex(index)
-        XCTAssertNil(barcode)
+        let result: TypeUnderTest? = readTransaction.readAtIndex(index)
+        XCTAssertNil(result)
     }
 
     func test__transaction__read_at_indexes_with_data() {
         configureForReadingMultiple()
-        let barcodes: [Barcode] = readTransaction.readAtIndexes(indexes)
-        XCTAssertEqual(barcodes.count, items.count)
+        let result: [TypeUnderTest] = readTransaction.readAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
     }
 
     func test__transaction__read_at_indexes_without_data() {
-        let barcodes: [Barcode] = readTransaction.readAtIndexes(indexes)
-        XCTAssertNotNil(barcodes)
-        XCTAssertTrue(barcodes.isEmpty)
+        let result: [TypeUnderTest] = readTransaction.readAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__transaction__read_by_key_with_data() {
         configureForReadingSingle()
-        let barcode: Barcode? = readTransaction.readByKey(key)
-        XCTAssertNotNil(barcode)
-        XCTAssertEqual(barcode!.identifier, item.identifier)
-        XCTAssertNil(barcode!.metadata)
+        let result: TypeUnderTest? = readTransaction.readByKey(key)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertNil(result!.metadata)
     }
 
     func test__transaction__read_by_key_without_data() {
-        let barcode: Barcode? = readTransaction.readByKey(key)
-        XCTAssertNil(barcode)
+        let result: TypeUnderTest? = readTransaction.readByKey(key)
+        XCTAssertNil(result)
     }
 
     func test__transaction__read_by_keys_with_data() {
         configureForReadingMultiple()
-        let barcodes: [Barcode] = readTransaction.readByKeys(keys)
-        XCTAssertEqual(barcodes.count, items.count)
+        let result: [TypeUnderTest] = readTransaction.readByKeys(keys)
+        XCTAssertEqual(result.count, items.count)
     }
 
     func test__transaction__read_by_keys_without_data() {
-        let barcodes: [Barcode] = readTransaction.readByKeys(keys)
-        XCTAssertNotNil(barcodes)
-        XCTAssertTrue(barcodes.isEmpty)
+        let result: [TypeUnderTest] = readTransaction.readByKeys(keys)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__transaction__read_all_with_data() {
         configureForReadingMultiple()
-        let result: [Barcode] = readTransaction.readAll()
+        let result: [TypeUnderTest] = readTransaction.readAll()
         XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
         XCTAssertEqual(result.count, items.count)
     }
@@ -526,57 +593,57 @@ class ValueWithNoMetadataTests: XCTestCase {
 
     func test__connection__read_at_index_with_data() {
         configureForReadingSingle()
-        let barcode: Barcode? = connection.readAtIndex(index)
-        XCTAssertNotNil(barcode)
-        XCTAssertEqual(barcode!.identifier, item.identifier)
-        XCTAssertNil(barcode!.metadata)
+        let result: TypeUnderTest? = connection.readAtIndex(index)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertNil(result!.metadata)
     }
 
     func test__connection__read_at_index_without_data() {
-        let barcode: Barcode? = connection.readAtIndex(index)
-        XCTAssertNil(barcode)
+        let result: TypeUnderTest? = connection.readAtIndex(index)
+        XCTAssertNil(result)
     }
 
     func test__connection__read_at_indexes_with_data() {
         configureForReadingMultiple()
-        let barcodes: [Barcode] = connection.readAtIndexes(indexes)
-        XCTAssertEqual(barcodes.count, items.count)
+        let result: [TypeUnderTest] = connection.readAtIndexes(indexes)
+        XCTAssertEqual(result.count, items.count)
     }
 
     func test__connection__read_at_indexes_without_data() {
-        let barcodes: [Barcode] = connection.readAtIndexes(indexes)
-        XCTAssertNotNil(barcodes)
-        XCTAssertTrue(barcodes.isEmpty)
+        let result: [TypeUnderTest] = connection.readAtIndexes(indexes)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__connection__read_by_key_with_data() {
         configureForReadingSingle()
-        let barcode: Barcode? = connection.readByKey(key)
-        XCTAssertNotNil(barcode)
-        XCTAssertEqual(barcode!.identifier, item.identifier)
-        XCTAssertNil(barcode!.metadata)
+        let result: TypeUnderTest? = connection.readByKey(key)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertNil(result!.metadata)
     }
 
     func test__connection__read_by_key_without_data() {
-        let barcode: Barcode? = connection.readByKey(key)
-        XCTAssertNil(barcode)
+        let result: TypeUnderTest? = connection.readByKey(key)
+        XCTAssertNil(result)
     }
 
     func test__connection__read_by_keys_with_data() {
         configureForReadingMultiple()
-        let barcodes: [Barcode] = connection.readByKeys(keys)
-        XCTAssertEqual(barcodes.count, items.count)
+        let result: [TypeUnderTest] = connection.readByKeys(keys)
+        XCTAssertEqual(result.count, items.count)
     }
 
     func test__connection__read_by_keys_without_data() {
-        let barcodes: [Barcode] = connection.readByKeys(keys)
-        XCTAssertNotNil(barcodes)
-        XCTAssertTrue(barcodes.isEmpty)
+        let result: [TypeUnderTest] = connection.readByKeys(keys)
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
     }
 
     func test__connection__read_all_with_data() {
         configureForReadingMultiple()
-        let result: [Barcode] = connection.readAll()
+        let result: [TypeUnderTest] = connection.readAll()
         XCTAssertTrue(connection.didRead)
         XCTAssertEqual(Set(readTransaction.didReadAtIndexes), Set(indexes))
         XCTAssertEqual(result.count, items.count)
@@ -589,7 +656,7 @@ class ValueWithNoMetadataTests: XCTestCase {
 
         XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
         XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
-        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
         XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
     }
 
@@ -609,7 +676,7 @@ class ValueWithNoMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didWrite)
         XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
         XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
-        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
         XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
     }
 
@@ -630,7 +697,7 @@ class ValueWithNoMetadataTests: XCTestCase {
         XCTAssertTrue(connection.didAsyncWrite)
         XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
         XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
-        XCTAssertEqual(Barcode.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
         XCTAssertNil(writeTransaction.didWriteAtIndexes[0].2)
     }
 

--- a/Tests/Shared/ValueWithObjectMetadataTests.swift
+++ b/Tests/Shared/ValueWithObjectMetadataTests.swift
@@ -583,6 +583,71 @@ class ValueWithObjectMetadataTests: XCTestCase {
         XCTAssertEqual(missing, Array(keys.suffixFrom(1)))
     }
 
+    // Persistable Curried API - Reading
+
+    func test__curried__read_at_index_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(result!.metadata, item.metadata)
+    }
+
+    func test__curried__read_at_index_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_at_indexes_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test__curried__read_by_key_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(result!.metadata, item.metadata)
+    }
+
+    func test__curried__read_by_key_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_by_keys_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // Persistable Curried API - Writing
+
+    func test__curried__writeOn() {
+        let result = connection.write(item.writeOn())
+
+        XCTAssertTrue(connection.didWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].2 as? NSNumber, item.metadata)
+        XCTAssertEqual(result, item)
+    }
+
     // Functional API - ReadTransactionType - Reading
 
     func test__transaction__read_at_index_with_data() {

--- a/Tests/Shared/ValueWithValueMetadataTests.swift
+++ b/Tests/Shared/ValueWithValueMetadataTests.swift
@@ -683,6 +683,71 @@ class ValueWithValueMetadataTests: XCTestCase {
         XCTAssertEqual(result.count, items.count)
     }
 
+    // Persistable Curried API - Reading
+
+    func test__curried__read_at_index_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(result!.metadata, item.metadata)
+    }
+
+    func test__curried__read_at_index_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndex(index))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_at_indexes_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_at_indexes_with_no_data() {
+        let result = connection.read(TypeUnderTest.readAtIndexes(indexes))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test__curried__read_by_key_with_data() {
+        configureForReadingSingle()
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.identifier, item.identifier)
+        XCTAssertEqual(result!.metadata, item.metadata)
+    }
+
+    func test__curried__read_by_key_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKey(key))
+        XCTAssertNil(result)
+    }
+
+    func test__curried__read_by_keys_with_data() {
+        configureForReadingMultiple()
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertEqual(result.count, items.count)
+    }
+
+    func test__curried__read_by_keys_with_no_data() {
+        let result = connection.read(TypeUnderTest.readByKeys(keys))
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // Persistable Curried API - Writing
+
+    func test__curried__writeOn() {
+        let result = connection.write(item.writeOn())
+
+        XCTAssertTrue(connection.didWrite)
+        XCTAssertFalse(writeTransaction.didWriteAtIndexes.isEmpty)
+        XCTAssertEqual(writeTransaction.didWriteAtIndexes[0].0, index)
+        XCTAssertEqual(TypeUnderTest.decode(writeTransaction.didWriteAtIndexes[0].1)!, item)
+        XCTAssertEqual(TypeUnderTest.MetadataType.decode(writeTransaction.didWriteAtIndexes[0].2), item.metadata)
+        XCTAssertEqual(result, item)
+    }
+
     // Functional API - ConnectionType - Reading
 
     func test__connection__read_at_index_with_data() {

--- a/YapDatabaseExtensions.xcodeproj/project.pbxproj
+++ b/YapDatabaseExtensions.xcodeproj/project.pbxproj
@@ -10,6 +10,11 @@
 		00EFE0D3D9A2DDD7C6BF526A /* Pods_YapDatabaseExtensions_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5550DE9AA69FDA43AE8D0D51 /* Pods_YapDatabaseExtensions_iOSTests.framework */; };
 		085C9EA234EAEF057CC78041 /* Pods_YapDatabaseExtensions_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE3D86AD60BF064ADA4CC71C /* Pods_YapDatabaseExtensions_iOS.framework */; };
 		371109FDB091F2E45241BC22 /* Pods_YapDatabaseExtensions_OSX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB4702C82EB6B1579DB4EF99 /* Pods_YapDatabaseExtensions_OSX.framework */; };
+		651DD4A41BCEF4D700DD94E2 /* Curried_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD49F1BCEF4D700DD94E2 /* Curried_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		651DD4A51BCEF4D700DD94E2 /* Curried_ObjectWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A01BCEF4D700DD94E2 /* Curried_ObjectWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		651DD4A61BCEF4D700DD94E2 /* Curried_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A11BCEF4D700DD94E2 /* Curried_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		651DD4A71BCEF4D700DD94E2 /* Curried_ValueWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A21BCEF4D700DD94E2 /* Curried_ValueWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		651DD4A81BCEF4D700DD94E2 /* Curried_ValueWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A31BCEF4D700DD94E2 /* Curried_ValueWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		653B044E1BC97ED700AC98FD /* YapDatabaseExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 653B04431BC97ED700AC98FD /* YapDatabaseExtensions.framework */; settings = {ASSET_TAGS = (); }; };
 		653B046A1BC9805D00AC98FD /* YapDatabaseExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 653B04601BC9805D00AC98FD /* YapDatabaseExtensions.framework */; settings = {ASSET_TAGS = (); }; };
 		653B047B1BC9816D00AC98FD /* YapDatabaseExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 653B04791BC9816D00AC98FD /* YapDatabaseExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -45,6 +50,8 @@
 		654EAE7D1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE7B1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		654EAE7F1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE7E1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		654EAE801BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654EAE7E1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		65BCF8C01BCED9D00023ED13 /* Curried_ObjectWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BCF8BF1BCED9D00023ED13 /* Curried_ObjectWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		65BCF8C11BCED9D00023ED13 /* Curried_ObjectWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BCF8BF1BCED9D00023ED13 /* Curried_ObjectWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5578B1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5578C1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		65C5578D1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5577E1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
@@ -108,6 +115,11 @@
 		574741755E625D8A78119A8A /* Pods_YapDatabaseExtensions_OSXTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_YapDatabaseExtensions_OSXTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		598392EAD289EAEAE8D3B2CD /* Pods-YapDatabaseExtensions-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YapDatabaseExtensions-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-YapDatabaseExtensions-iOS/Pods-YapDatabaseExtensions-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		5AC602528D550B8182F7A0C6 /* Pods-YapDatabaseExtensions-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-YapDatabaseExtensions-iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-YapDatabaseExtensions-iOS/Pods-YapDatabaseExtensions-iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		651DD49F1BCEF4D700DD94E2 /* Curried_ObjectWithObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Curried_ObjectWithObjectMetadata.swift; path = Curried/Curried_ObjectWithObjectMetadata.swift; sourceTree = "<group>"; };
+		651DD4A01BCEF4D700DD94E2 /* Curried_ObjectWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Curried_ObjectWithValueMetadata.swift; path = Curried/Curried_ObjectWithValueMetadata.swift; sourceTree = "<group>"; };
+		651DD4A11BCEF4D700DD94E2 /* Curried_ValueWithNoMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Curried_ValueWithNoMetadata.swift; path = Curried/Curried_ValueWithNoMetadata.swift; sourceTree = "<group>"; };
+		651DD4A21BCEF4D700DD94E2 /* Curried_ValueWithObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Curried_ValueWithObjectMetadata.swift; path = Curried/Curried_ValueWithObjectMetadata.swift; sourceTree = "<group>"; };
+		651DD4A31BCEF4D700DD94E2 /* Curried_ValueWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Curried_ValueWithValueMetadata.swift; path = Curried/Curried_ValueWithValueMetadata.swift; sourceTree = "<group>"; };
 		653B04431BC97ED700AC98FD /* YapDatabaseExtensions.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YapDatabaseExtensions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		653B044D1BC97ED700AC98FD /* YapDatabaseExtensions-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "YapDatabaseExtensions-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		653B04601BC9805D00AC98FD /* YapDatabaseExtensions.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = YapDatabaseExtensions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -132,6 +144,7 @@
 		654EAE781BCD45480093AB0C /* Functional_AnyWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_AnyWithValueMetadata.swift; sourceTree = "<group>"; };
 		654EAE7B1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Persistable_AnyWithObjectMetadata.swift; sourceTree = "<group>"; };
 		654EAE7E1BCD4CD70093AB0C /* Persistable_AnyWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Persistable_AnyWithValueMetadata.swift; sourceTree = "<group>"; };
+		65BCF8BF1BCED9D00023ED13 /* Curried_ObjectWithNoMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Curried_ObjectWithNoMetadata.swift; path = Curried/Curried_ObjectWithNoMetadata.swift; sourceTree = "<group>"; };
 		65C5577D1BCB26010065C96A /* Functional_ObjectWithObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ObjectWithObjectMetadata.swift; sourceTree = "<group>"; };
 		65C5577E1BCB26010065C96A /* Functional_ObjectWithValueMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ObjectWithValueMetadata.swift; sourceTree = "<group>"; };
 		65C5577F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Functional_ValueWIthObjectMetadata.swift; sourceTree = "<group>"; };
@@ -230,10 +243,11 @@
 		653B047C1BC981D100AC98FD /* Shared */ = {
 			isa = PBXGroup;
 			children = (
-				65C5577C1BCB26010065C96A /* Functional */,
-				65C557811BCB26010065C96A /* Persistable */,
 				653B04801BC981D100AC98FD /* YapDatabaseExtensions.swift */,
 				653B04811BC981D100AC98FD /* YapDB.swift */,
+				65C5577C1BCB26010065C96A /* Functional */,
+				65BCF8C21BCED9D80023ED13 /* Curried */,
+				65C557811BCB26010065C96A /* Persistable */,
 			);
 			name = Shared;
 			path = YapDatabaseExtensions/Shared;
@@ -272,6 +286,19 @@
 				653B047C1BC981D100AC98FD /* Shared */,
 			);
 			name = YapDatabaseExtensions;
+			sourceTree = "<group>";
+		};
+		65BCF8C21BCED9D80023ED13 /* Curried */ = {
+			isa = PBXGroup;
+			children = (
+				65BCF8BF1BCED9D00023ED13 /* Curried_ObjectWithNoMetadata.swift */,
+				651DD49F1BCEF4D700DD94E2 /* Curried_ObjectWithObjectMetadata.swift */,
+				651DD4A01BCEF4D700DD94E2 /* Curried_ObjectWithValueMetadata.swift */,
+				651DD4A11BCEF4D700DD94E2 /* Curried_ValueWithNoMetadata.swift */,
+				651DD4A21BCEF4D700DD94E2 /* Curried_ValueWithObjectMetadata.swift */,
+				651DD4A31BCEF4D700DD94E2 /* Curried_ValueWithValueMetadata.swift */,
+			);
+			name = Curried;
 			sourceTree = "<group>";
 		};
 		65C5577C1BCB26010065C96A /* Functional */ = {
@@ -676,16 +703,22 @@
 				65C557A61BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579B1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
 				65C5579D1BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift in Sources */,
+				651DD4A51BCEF4D700DD94E2 /* Curried_ObjectWithValueMetadata.swift in Sources */,
+				651DD4A81BCEF4D700DD94E2 /* Curried_ValueWithValueMetadata.swift in Sources */,
 				65C8DB441BCD24FA002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */,
+				651DD4A61BCEF4D700DD94E2 /* Curried_ValueWithNoMetadata.swift in Sources */,
 				65C8DB491BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift in Sources */,
 				65C8DB4C1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift in Sources */,
 				65C8DB421BCD24EA002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */,
 				654EAE761BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift in Sources */,
 				65C557A31BCB26010065C96A /* Write.swift in Sources */,
 				65C557911BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
+				65BCF8C01BCED9D00023ED13 /* Curried_ObjectWithNoMetadata.swift in Sources */,
 				65C5578F1BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
+				651DD4A71BCEF4D700DD94E2 /* Curried_ValueWithObjectMetadata.swift in Sources */,
 				653B04851BC981D100AC98FD /* YapDatabaseExtensions.swift in Sources */,
 				65C557951BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift in Sources */,
+				651DD4A41BCEF4D700DD94E2 /* Curried_ObjectWithObjectMetadata.swift in Sources */,
 				654EAE7C1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift in Sources */,
 				65C557A11BCB26010065C96A /* Remove.swift in Sources */,
 				65C557971BCB26010065C96A /* Persistable_ObjectWithValueMetadata.swift in Sources */,
@@ -730,6 +763,7 @@
 				654EAE771BCD44D90093AB0C /* Functional_AnyWithObjectMetadata.swift in Sources */,
 				65C557A41BCB26010065C96A /* Write.swift in Sources */,
 				65C557921BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
+				65BCF8C11BCED9D00023ED13 /* Curried_ObjectWithNoMetadata.swift in Sources */,
 				65C557901BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
 				653B048A1BC981D700AC98FD /* YapDatabaseExtensions.swift in Sources */,
 				65C557961BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift in Sources */,

--- a/YapDatabaseExtensions.xcodeproj/project.pbxproj
+++ b/YapDatabaseExtensions.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		651DD4A61BCEF4D700DD94E2 /* Curried_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A11BCEF4D700DD94E2 /* Curried_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		651DD4A71BCEF4D700DD94E2 /* Curried_ValueWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A21BCEF4D700DD94E2 /* Curried_ValueWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		651DD4A81BCEF4D700DD94E2 /* Curried_ValueWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A31BCEF4D700DD94E2 /* Curried_ValueWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		652DE6591BCEF8D700B5E668 /* Curried_ObjectWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD49F1BCEF4D700DD94E2 /* Curried_ObjectWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		652DE65A1BCEF8D700B5E668 /* Curried_ObjectWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A01BCEF4D700DD94E2 /* Curried_ObjectWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		652DE65B1BCEF8D700B5E668 /* Curried_ValueWithNoMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A11BCEF4D700DD94E2 /* Curried_ValueWithNoMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		652DE65C1BCEF8D700B5E668 /* Curried_ValueWithObjectMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A21BCEF4D700DD94E2 /* Curried_ValueWithObjectMetadata.swift */; settings = {ASSET_TAGS = (); }; };
+		652DE65D1BCEF8D700B5E668 /* Curried_ValueWithValueMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651DD4A31BCEF4D700DD94E2 /* Curried_ValueWithValueMetadata.swift */; settings = {ASSET_TAGS = (); }; };
 		653B044E1BC97ED700AC98FD /* YapDatabaseExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 653B04431BC97ED700AC98FD /* YapDatabaseExtensions.framework */; settings = {ASSET_TAGS = (); }; };
 		653B046A1BC9805D00AC98FD /* YapDatabaseExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 653B04601BC9805D00AC98FD /* YapDatabaseExtensions.framework */; settings = {ASSET_TAGS = (); }; };
 		653B047B1BC9816D00AC98FD /* YapDatabaseExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 653B04791BC9816D00AC98FD /* YapDatabaseExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -756,7 +761,10 @@
 				65C557A71BCB26310065C96A /* Functional_Remove.swift in Sources */,
 				65C5579C1BCB26010065C96A /* Persistable_ValueWithObjectMetadata.swift in Sources */,
 				65C5579E1BCB26010065C96A /* Persistable_ValueWithValueMetadata.swift in Sources */,
+				652DE65A1BCEF8D700B5E668 /* Curried_ObjectWithValueMetadata.swift in Sources */,
+				652DE65D1BCEF8D700B5E668 /* Curried_ValueWithValueMetadata.swift in Sources */,
 				65C8DB451BCD24FB002F2C05 /* Persistable_ValueWithNoMetadata.swift in Sources */,
+				652DE65B1BCEF8D700B5E668 /* Curried_ValueWithNoMetadata.swift in Sources */,
 				65C8DB4A1BCD2676002F2C05 /* Functional_ObjectWithNoMetadata.swift in Sources */,
 				65C8DB4D1BCD283D002F2C05 /* Functional_ValueWithNoMetadata.swift in Sources */,
 				65C8DB431BCD24EB002F2C05 /* Persistable_ObjectWithNoMetadata.swift in Sources */,
@@ -765,8 +773,10 @@
 				65C557921BCB26010065C96A /* Functional_ValueWIthValueMetadata.swift in Sources */,
 				65BCF8C11BCED9D00023ED13 /* Curried_ObjectWithNoMetadata.swift in Sources */,
 				65C557901BCB26010065C96A /* Functional_ValueWIthObjectMetadata.swift in Sources */,
+				652DE65C1BCEF8D700B5E668 /* Curried_ValueWithObjectMetadata.swift in Sources */,
 				653B048A1BC981D700AC98FD /* YapDatabaseExtensions.swift in Sources */,
 				65C557961BCB26010065C96A /* Persistable_ObjectWithObjectMetadata.swift in Sources */,
+				652DE6591BCEF8D700B5E668 /* Curried_ObjectWithObjectMetadata.swift in Sources */,
 				654EAE7D1BCD4C6B0093AB0C /* Persistable_AnyWithObjectMetadata.swift in Sources */,
 				65C557A21BCB26010065C96A /* Remove.swift in Sources */,
 				65C557981BCB26010065C96A /* Persistable_ObjectWithValueMetadata.swift in Sources */,

--- a/YapDatabaseExtensions/Shared/Curried/Curried_ObjectWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Curried/Curried_ObjectWithNoMetadata.swift
@@ -1,0 +1,84 @@
+//
+//  Curried_ObjectWithNoMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 14/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+
+// MARK: - Persistable
+
+extension Persistable where
+    Self: NSCoding,
+    Self.MetadataType == Void {
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given index.
+    
+    - parameter index: a YapDB.Index
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readAtIndex<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(index: YapDB.Index) -> ReadTransaction -> Self? {
+            return { $0.readAtIndex(index) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given indexes.
+
+    - parameter indexes: a SequenceType of YapDB.Index values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readAtIndexes<
+        Indexes, ReadTransaction where
+        Indexes: SequenceType,
+        Indexes.Generator.Element == YapDB.Index,
+        ReadTransaction: ReadTransactionType>(indexes: Indexes) -> ReadTransaction -> [Self] {
+            return { $0.readAtIndexes(indexes) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given key.
+
+    - parameter key: a String
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readByKey<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(key: String) -> ReadTransaction -> Self? {
+            return { $0.readByKey(key) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given keys.
+
+    - parameter keys: a SequenceType of String values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readByKeys<
+        Keys, ReadTransaction where
+        Keys: SequenceType,
+        Keys.Generator.Element == String,
+        ReadTransaction: ReadTransactionType>(keys: Keys) -> ReadTransaction -> [Self] {
+            return  { $0.readAtIndexes(Self.indexesWithKeys(keys)) }
+    }
+
+    /**
+    Returns a closure which, given a write transaction will write
+    and return the item.
+    
+    - warning: Be aware that this will capure `self`.
+    - returns: a (WriteTransaction) -> Self closure
+    */
+    public func writeOn<WriteTransaction: WriteTransactionType>() -> WriteTransaction -> Self {
+        return { $0.write(self) }
+    }
+}

--- a/YapDatabaseExtensions/Shared/Curried/Curried_ObjectWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Curried/Curried_ObjectWithObjectMetadata.swift
@@ -1,0 +1,84 @@
+//
+//  Curried_ObjectWithObjectMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 14/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+
+// MARK: - Persistable
+
+extension Persistable where
+    Self: NSCoding,
+    Self.MetadataType: NSCoding {
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given index.
+    
+    - parameter index: a YapDB.Index
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readAtIndex<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(index: YapDB.Index) -> ReadTransaction -> Self? {
+            return { $0.readAtIndex(index) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given indexes.
+
+    - parameter indexes: a SequenceType of YapDB.Index values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readAtIndexes<
+        Indexes, ReadTransaction where
+        Indexes: SequenceType,
+        Indexes.Generator.Element == YapDB.Index,
+        ReadTransaction: ReadTransactionType>(indexes: Indexes) -> ReadTransaction -> [Self] {
+            return { $0.readAtIndexes(indexes) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given key.
+
+    - parameter key: a String
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readByKey<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(key: String) -> ReadTransaction -> Self? {
+            return { $0.readByKey(key) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given keys.
+
+    - parameter keys: a SequenceType of String values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readByKeys<
+        Keys, ReadTransaction where
+        Keys: SequenceType,
+        Keys.Generator.Element == String,
+        ReadTransaction: ReadTransactionType>(keys: Keys) -> ReadTransaction -> [Self] {
+            return  { $0.readAtIndexes(Self.indexesWithKeys(keys)) }
+    }
+
+    /**
+    Returns a closure which, given a write transaction will write
+    and return the item.
+    
+    - warning: Be aware that this will capure `self`.
+    - returns: a (WriteTransaction) -> Self closure
+    */
+    public func writeOn<WriteTransaction: WriteTransactionType>() -> WriteTransaction -> Self {
+        return { $0.write(self) }
+    }
+}

--- a/YapDatabaseExtensions/Shared/Curried/Curried_ObjectWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Curried/Curried_ObjectWithValueMetadata.swift
@@ -1,0 +1,86 @@
+//
+//  Curried_ObjectWithValueMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 14/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+
+// MARK: - Persistable
+
+extension Persistable where
+    Self: NSCoding,
+    Self.MetadataType: ValueCoding,
+    Self.MetadataType.Coder: NSCoding,
+    Self.MetadataType.Coder.ValueType == Self.MetadataType {
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given index.
+    
+    - parameter index: a YapDB.Index
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readAtIndex<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(index: YapDB.Index) -> ReadTransaction -> Self? {
+            return { $0.readAtIndex(index) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given indexes.
+
+    - parameter indexes: a SequenceType of YapDB.Index values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readAtIndexes<
+        Indexes, ReadTransaction where
+        Indexes: SequenceType,
+        Indexes.Generator.Element == YapDB.Index,
+        ReadTransaction: ReadTransactionType>(indexes: Indexes) -> ReadTransaction -> [Self] {
+            return { $0.readAtIndexes(indexes) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given key.
+
+    - parameter key: a String
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readByKey<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(key: String) -> ReadTransaction -> Self? {
+            return { $0.readByKey(key) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given keys.
+
+    - parameter keys: a SequenceType of String values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readByKeys<
+        Keys, ReadTransaction where
+        Keys: SequenceType,
+        Keys.Generator.Element == String,
+        ReadTransaction: ReadTransactionType>(keys: Keys) -> ReadTransaction -> [Self] {
+            return  { $0.readAtIndexes(Self.indexesWithKeys(keys)) }
+    }
+
+    /**
+    Returns a closure which, given a write transaction will write
+    and return the item.
+    
+    - warning: Be aware that this will capure `self`.
+    - returns: a (WriteTransaction) -> Self closure
+    */
+    public func writeOn<WriteTransaction: WriteTransactionType>() -> WriteTransaction -> Self {
+        return { $0.write(self) }
+    }
+}

--- a/YapDatabaseExtensions/Shared/Curried/Curried_ValueWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Curried/Curried_ValueWithNoMetadata.swift
@@ -1,0 +1,86 @@
+//
+//  Curried_ValueWithNoMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 14/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+
+// MARK: - Persistable
+
+extension Persistable where
+    Self: ValueCoding,
+    Self.Coder: NSCoding,
+    Self.Coder.ValueType == Self,
+    Self.MetadataType == Void {
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given index.
+    
+    - parameter index: a YapDB.Index
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readAtIndex<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(index: YapDB.Index) -> ReadTransaction -> Self? {
+            return { $0.readAtIndex(index) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given indexes.
+
+    - parameter indexes: a SequenceType of YapDB.Index values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readAtIndexes<
+        Indexes, ReadTransaction where
+        Indexes: SequenceType,
+        Indexes.Generator.Element == YapDB.Index,
+        ReadTransaction: ReadTransactionType>(indexes: Indexes) -> ReadTransaction -> [Self] {
+            return { $0.readAtIndexes(indexes) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given key.
+
+    - parameter key: a String
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readByKey<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(key: String) -> ReadTransaction -> Self? {
+            return { $0.readByKey(key) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given keys.
+
+    - parameter keys: a SequenceType of String values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readByKeys<
+        Keys, ReadTransaction where
+        Keys: SequenceType,
+        Keys.Generator.Element == String,
+        ReadTransaction: ReadTransactionType>(keys: Keys) -> ReadTransaction -> [Self] {
+            return  { $0.readAtIndexes(Self.indexesWithKeys(keys)) }
+    }
+
+    /**
+    Returns a closure which, given a write transaction will write
+    and return the item.
+    
+    - warning: Be aware that this will capure `self`.
+    - returns: a (WriteTransaction) -> Self closure
+    */
+    public func writeOn<WriteTransaction: WriteTransactionType>() -> WriteTransaction -> Self {
+        return { $0.write(self) }
+    }
+}

--- a/YapDatabaseExtensions/Shared/Curried/Curried_ValueWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Curried/Curried_ValueWithObjectMetadata.swift
@@ -1,0 +1,86 @@
+//
+//  Curried_ValueWithObjectMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 14/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+
+// MARK: - Persistable
+
+extension Persistable where
+    Self: ValueCoding,
+    Self.Coder: NSCoding,
+    Self.Coder.ValueType == Self,
+    Self.MetadataType: NSCoding {
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given index.
+    
+    - parameter index: a YapDB.Index
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readAtIndex<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(index: YapDB.Index) -> ReadTransaction -> Self? {
+            return { $0.readAtIndex(index) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given indexes.
+
+    - parameter indexes: a SequenceType of YapDB.Index values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readAtIndexes<
+        Indexes, ReadTransaction where
+        Indexes: SequenceType,
+        Indexes.Generator.Element == YapDB.Index,
+        ReadTransaction: ReadTransactionType>(indexes: Indexes) -> ReadTransaction -> [Self] {
+            return { $0.readAtIndexes(indexes) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given key.
+
+    - parameter key: a String
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readByKey<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(key: String) -> ReadTransaction -> Self? {
+            return { $0.readByKey(key) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given keys.
+
+    - parameter keys: a SequenceType of String values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readByKeys<
+        Keys, ReadTransaction where
+        Keys: SequenceType,
+        Keys.Generator.Element == String,
+        ReadTransaction: ReadTransactionType>(keys: Keys) -> ReadTransaction -> [Self] {
+            return  { $0.readAtIndexes(Self.indexesWithKeys(keys)) }
+    }
+
+    /**
+    Returns a closure which, given a write transaction will write
+    and return the item.
+    
+    - warning: Be aware that this will capure `self`.
+    - returns: a (WriteTransaction) -> Self closure
+    */
+    public func writeOn<WriteTransaction: WriteTransactionType>() -> WriteTransaction -> Self {
+        return { $0.write(self) }
+    }
+}

--- a/YapDatabaseExtensions/Shared/Curried/Curried_ValueWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Curried/Curried_ValueWithValueMetadata.swift
@@ -1,0 +1,88 @@
+//
+//  Curried_ValueWithValueMetadata.swift
+//  YapDatabaseExtensions
+//
+//  Created by Daniel Thorpe on 14/10/2015.
+//
+//
+
+import Foundation
+import ValueCoding
+
+// MARK: - Persistable
+
+extension Persistable where
+    Self: ValueCoding,
+    Self.Coder: NSCoding,
+    Self.Coder.ValueType == Self,
+    Self.MetadataType: ValueCoding,
+    Self.MetadataType.Coder: NSCoding,
+    Self.MetadataType.Coder.ValueType == Self.MetadataType {
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given index.
+    
+    - parameter index: a YapDB.Index
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readAtIndex<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(index: YapDB.Index) -> ReadTransaction -> Self? {
+            return { $0.readAtIndex(index) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given indexes.
+
+    - parameter indexes: a SequenceType of YapDB.Index values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readAtIndexes<
+        Indexes, ReadTransaction where
+        Indexes: SequenceType,
+        Indexes.Generator.Element == YapDB.Index,
+        ReadTransaction: ReadTransactionType>(indexes: Indexes) -> ReadTransaction -> [Self] {
+            return { $0.readAtIndexes(indexes) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the item at the given key.
+
+    - parameter key: a String
+    - returns: a (ReadTransaction) -> Self? closure.
+    */
+    public static func readByKey<
+        ReadTransaction where
+        ReadTransaction: ReadTransactionType>(key: String) -> ReadTransaction -> Self? {
+            return { $0.readByKey(key) }
+    }
+
+    /**
+    Returns a closure which, given a read transaction will return
+    the items at the given keys.
+
+    - parameter keys: a SequenceType of String values
+    - returns: a (ReadTransaction) -> [Self] closure.
+    */
+    public static func readByKeys<
+        Keys, ReadTransaction where
+        Keys: SequenceType,
+        Keys.Generator.Element == String,
+        ReadTransaction: ReadTransactionType>(keys: Keys) -> ReadTransaction -> [Self] {
+            return  { $0.readAtIndexes(Self.indexesWithKeys(keys)) }
+    }
+
+    /**
+    Returns a closure which, given a write transaction will write
+    and return the item.
+    
+    - warning: Be aware that this will capure `self`.
+    - returns: a (WriteTransaction) -> Self closure
+    */
+    public func writeOn<WriteTransaction: WriteTransactionType>() -> WriteTransaction -> Self {
+        return { $0.write(self) }
+    }
+}

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_AnyWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_AnyWithObjectMetadata.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ValueCoding
-import YapDatabase
 
 // MARK: - Readable
 

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_AnyWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_AnyWithValueMetadata.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ValueCoding
-import YapDatabase
 
 // MARK: - Readable
 

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithNoMetadata.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ValueCoding
-import YapDatabase
 
 // MARK: - Readable
 
@@ -174,4 +173,6 @@ extension Writable
         return connection.writeBlockOperation { self.on($0) }
     }
 }
+
+
 

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithObjectMetadata.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ValueCoding
-import YapDatabase
 
 // MARK: - Readable
 

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ObjectWithValueMetadata.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ValueCoding
-import YapDatabase
 
 // MARK: - Readable
 

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithNoMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithNoMetadata.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ValueCoding
-import YapDatabase
 
 // MARK: - Readable
 

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithObjectMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithObjectMetadata.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ValueCoding
-import YapDatabase
 
 // MARK: - Readable
 

--- a/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithValueMetadata.swift
+++ b/YapDatabaseExtensions/Shared/Persistable/Persistable_ValueWithValueMetadata.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import ValueCoding
-import YapDatabase
 
 // MARK: - Readable
 


### PR DESCRIPTION
This is sort of half way between the functional and persistable APIs

``` swift
extension Persistable where
    Self: NSCoding,
    Self.MetadataType == Void {

    public static func readAtIndex<ReadTransaction: ReadTransactionType>(index: YapDB.Index) -> ReadTransaction -> Self? {
        return { $0.readAtIndex(index) }
    }
}
```

Usage...

``` swift
let item = connection.read(Item.readAtIndex(index))
```

But would also quite nicely for enumerator, or "fetchers" whereby it is possible to store as a property a closure which receives a read transaction and would return the typed item. This can be passed around and used multiple times. 
