### PR TITLE
Group "functional" and "persistable" APIs under one header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ Item encoding | Metadata encoding | Pattern
 `ValueCoding` | `NSCoding`        | ValueWithObjectMetadata
 `ValueCoding` | `ValueCoding`     | ValueWithValueMetadata
 
-There are also two styles of API. The *functional* API works on `YapDatabase` types, `YapDatabaseReadTransaction`, `YapDatabaseReadWriteTransaction` and `YapDatabaseConnection`. The *persistable* API works on your `Persistable` types directly, and receives the `YapDatabase` type as arguments.
+## Swifty APIs
 
-## Functional API
+YapDatabaseExtensions provides two styles of API. The *functional* API works on `YapDatabase` types, `YapDatabaseReadTransaction`, `YapDatabaseReadWriteTransaction` and `YapDatabaseConnection`. The *persistable* API works on your `Persistable` types directly, and receives the `YapDatabase` type as arguments.
+
+### Functional API
 
 The following “functional” APIs are available directly on the `YapDatabase` types.
 
@@ -141,7 +143,7 @@ connection.read { transaction in
 }
 ```
 
-## `Persistable` API
+### `Persistable` API
 
 The APIs all work on single or sequences of `Persistable` items. To write to the database:
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Item encoding | Metadata encoding | Pattern
 `ValueCoding` | `NSCoding`        | ValueWithObjectMetadata
 `ValueCoding` | `ValueCoding`     | ValueWithValueMetadata
 
-## Swifty APIs
+## Extension APIs
 
 YapDatabaseExtensions provides two styles of API. The *functional* API works on `YapDatabase` types, `YapDatabaseReadTransaction`, `YapDatabaseReadWriteTransaction` and `YapDatabaseConnection`. The *persistable* API works on your `Persistable` types directly, and receives the `YapDatabase` type as arguments.
 


### PR DESCRIPTION
When reading the README, I found it strange that the paragraph

> There are also two styles of API. The _functional_ API works on `YapDatabase` types, …

was under the “Correct Type Patterns” header.

This minor change resolves that confusion, IMO, by introducing a new header above that paragraph and bumping the Functional and Persistable API headers down to `h3` from `h2`.
